### PR TITLE
feat: 增加对移动端低版本和其他浏览器兼容性

### DIFF
--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -22,6 +22,11 @@
     "tsx": "^3.12.7"
   },
   "devDependencies": {
+    "@babel/core": "^7.25.2",
+    "@babel/plugin-transform-runtime": "^7.24.7",
+    "@babel/preset-env": "^7.25.3",
+    "@babel/runtime": "^7.25.0",
+    "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^23.0.2",
     "@rollup/plugin-json": "^5.0.1",
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/packages/parser/rollup.config.js
+++ b/packages/parser/rollup.config.js
@@ -1,6 +1,7 @@
 import typescript from "rollup-plugin-typescript2";
 import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
+import { getBabelOutputPlugin } from '@rollup/plugin-babel'
 
 const mode = process.env.MODE ?? 'prod';
 const isProd = mode === "prod";
@@ -23,6 +24,19 @@ export default [
             declarationDir: "build/es"
           }, include: ["src"]
         }
+      }), 
+      getBabelOutputPlugin({
+        presets: [
+          [
+            '@babel/preset-env',
+            {
+              modules: false,
+              useBuiltIns: 'usage',
+              corejs: '3.6.4',
+            },
+          ],
+        ],
+        plugins: ['@babel/plugin-transform-runtime'],
       })]
   }, {
     input: `./src/index.ts`,

--- a/packages/webgal/package.json
+++ b/packages/webgal/package.json
@@ -4,7 +4,7 @@
   "version": "4.5.4",
   "scripts": {
     "dev": "vite --host --port 3000",
-    "build": "cross-env NODE_ENV=production tsc && vite build --base=./",
+    "build": "cross-env NODE_ENV=production NODE_OPTIONS=--max-old-space-size=4096 tsc && vite build --base=./",
     "preview": "vite preview",
     "lint": "eslint src/** --fix"
   },

--- a/packages/webgal/package.json
+++ b/packages/webgal/package.json
@@ -41,6 +41,7 @@
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.18.0",
     "@typescript-eslint/parser": "^5.18.0",
+    "@vitejs/plugin-legacy": "^5.4.1",
     "@vitejs/plugin-react": "^4.0.4",
     "cross-env": "^7.0.3",
     "eslint": "^8.13.0",

--- a/packages/webgal/vite.config.ts
+++ b/packages/webgal/vite.config.ts
@@ -59,4 +59,7 @@ export default defineConfig({
       '@': resolve('src'),
     },
   },
+  build: {
+    sourcemap: true,
+  },
 });

--- a/packages/webgal/vite.config.ts
+++ b/packages/webgal/vite.config.ts
@@ -5,6 +5,7 @@ import { resolve, relative } from 'path';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { readdirSync, watch, writeFileSync } from 'fs';
 import { isEqual } from 'lodash';
+import legacy from '@vitejs/plugin-legacy'
 // https://vitejs.dev/config/
 
 // @ts-ignore
@@ -51,13 +52,11 @@ export default defineConfig({
     loadVersion(),
     // @ts-ignore
     visualizer(),
+    legacy(),
   ],
   resolve: {
     alias: {
       '@': resolve('src'),
     },
-  },
-  build: {
-    sourcemap: true,
-  },
+  }
 });

--- a/packages/webgal/vite.config.ts
+++ b/packages/webgal/vite.config.ts
@@ -5,7 +5,7 @@ import { resolve, relative } from 'path';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { readdirSync, watch, writeFileSync } from 'fs';
 import { isEqual } from 'lodash';
-import legacy from '@vitejs/plugin-legacy'
+import legacy from '@vitejs/plugin-legacy';
 // https://vitejs.dev/config/
 
 // @ts-ignore
@@ -58,5 +58,5 @@ export default defineConfig({
     alias: {
       '@': resolve('src'),
     },
-  }
+  },
 });


### PR DESCRIPTION
1. parser 增加了 rollup 过 babel 一系列依赖，保证产物不会出现 es5 以上语法;
2. webgal 增加 legacy 做同样的处理；
3. 目前打包时过 legacy 在一些内存较小的机器可能会出现内存不足，短线关闭 sourcemap 可以解决，长线可以优化下目前 webgal 的依赖引用 