### PR TITLE
fix: var value handle

### DIFF
--- a/packages/webgal/src/Core/controller/gamePlay/scriptExecutor.ts
+++ b/packages/webgal/src/Core/controller/gamePlay/scriptExecutor.ts
@@ -4,7 +4,7 @@ import { logger } from '../../util/logger';
 import { IStageState } from '@/store/stageInterface';
 import { restoreScene } from '../scene/restoreScene';
 import { webgalStore } from '@/store/store';
-import { getValueFromState } from '@/Core/gameScripts/setVar';
+import { getValueFromStateElseKey } from '@/Core/gameScripts/setVar';
 import { strIf } from '@/Core/controller/gamePlay/strIf';
 import { nextSentence } from '@/Core/controller/gamePlay/nextSentence';
 import cloneDeep from 'lodash/cloneDeep';
@@ -25,7 +25,7 @@ export const whenChecker = (whenValue: string | undefined): boolean => {
         if (e.match(/true/) || e.match(/false/)) {
           return e;
         }
-        return getValueFromState(e).toString();
+        return getValueFromStateElseKey(e);
       } else return e;
     })
     .reduce((pre, curr) => pre + curr, '');
@@ -59,8 +59,8 @@ export const scriptExecutor = () => {
 
     if (contentExp !== null) {
       contentExp.forEach((e) => {
-        const contentVarValue = getValueFromState(e.replace(/(?<!\\)\{(.*)\}/, '$1'));
-        retContent = retContent.replace(e, contentVarValue ? contentVarValue.toString() : e);
+        const contentVarValue = getValueFromStateElseKey(e.replace(/(?<!\\)\{(.*)\}/, '$1'));
+        retContent = retContent.replace(e, contentVarValue);
       });
     }
     retContent = retContent.replace(/\\{/g, '{').replace(/\\}/g, '}');

--- a/packages/webgal/src/Core/gameScripts/setVar.ts
+++ b/packages/webgal/src/Core/gameScripts/setVar.ts
@@ -39,6 +39,10 @@ export const setVar = (sentence: ISentence): IPerform => {
       // 将变量替换为变量的值，然后合成表达式字符串
       const valExp2 = valExpArr
         .map((e) => {
+          if (!e.trim().match(/^[a-zA-Z_][a-zA-Z0-9_]*$/)) {
+            // 检查是否是变量名，不是就返回本身
+            return e;
+          }
           const _r = getValueFromStateElseKey(e.trim());
           return typeof _r === 'string' ? `'${_r}'` : _r;
         })

--- a/packages/webgal/src/Core/gameScripts/setVar.ts
+++ b/packages/webgal/src/Core/gameScripts/setVar.ts
@@ -39,10 +39,8 @@ export const setVar = (sentence: ISentence): IPerform => {
       // 将变量替换为变量的值，然后合成表达式字符串
       const valExp2 = valExpArr
         .map((e) => {
-          if (e.match(/\$?[.a-zA-Z]/)) {
-            const _r = getValueFromStateElseKey(e.trim());
-            return typeof _r === 'string' ? `'${_r}'` : _r;
-          } else return e;
+          const _r = getValueFromStateElseKey(e.trim());
+          return typeof _r === 'string' ? `'${_r}'` : _r;
         })
         .reduce((pre, curr) => pre + curr, '');
       let result = '';
@@ -60,7 +58,7 @@ export const setVar = (sentence: ISentence): IPerform => {
       if (valExp.match(/false/)) {
         webgalStore.dispatch(targetReducerFunction({ key, value: false }));
       }
-    } else if (valExp.length == 0) {
+    } else if (valExp.length === 0) {
       webgalStore.dispatch(targetReducerFunction({ key, value: '' }));
     } else {
       if (!isNaN(Number(valExp))) {
@@ -93,7 +91,7 @@ type BaseVal = string | number | boolean | undefined;
  * 取不到时返回 undefined
  */
 export function getValueFromState(key: string) {
-  let ret: any = undefined;
+  let ret: any;
   const stage = webgalStore.getState().stage;
   const userData = webgalStore.getState().userData;
   const _Merge = { stage, userData }; // 不要直接合并到一起，防止可能的键冲突
@@ -113,8 +111,9 @@ export function getValueFromState(key: string) {
  */
 export function getValueFromStateElseKey(key: string) {
   const valueFromState = getValueFromState(key);
-  if (valueFromState == null) {
+  if (valueFromState === null || valueFromState === undefined) {
     logger.warn('valueFromState result null, key = ' + key);
+    return key;
   }
-  return valueFromState != null ? valueFromState : key;
+  return valueFromState;
 }


### PR DESCRIPTION
resolve #528 
resolve #527 

以及实现:
> setVar:emptyText=; 预期赋值为空字符创

鉴于多处对于`getValueFromState`取不到都需要处理，统一包成`getValueFromStateElseKey`。

测试用例：
```
setVar:zero=0;
setVar:emptyText=;
Tester:absent var shows as {absent}, zero var shows as {zero}, empty text var shows as {emptyText}.
setVar:ref_absent=absent;
setVar:ref_zero=zero;
setVar:ref_emptyText=emptyText;
Tester:ref_absent var shows as {ref_absent}, ref_zero var shows as {ref_zero}, ref_empty text var shows as {ref_emptyText}.
setVar:computed=zero + zero;
Tester:computed zero var shows as {computed}
```