### PR TITLE
优化富文本显示排版

### DIFF
--- a/packages/webgal/src/Stage/TextBox/IMSSTextbox.tsx
+++ b/packages/webgal/src/Stage/TextBox/IMSSTextbox.tsx
@@ -4,6 +4,7 @@ import { WebGAL } from '@/Core/WebGAL';
 import { ITextboxProps } from './types';
 import useApplyStyle from '@/hooks/useApplyStyle';
 import { css } from '@emotion/css';
+import { textSize } from '@/store/userDataInterface';
 
 export default function IMSSTextbox(props: ITextboxProps) {
   const {
@@ -22,6 +23,7 @@ export default function IMSSTextbox(props: ITextboxProps) {
     textDuration,
     isUseStroke,
     textboxOpacity,
+    textSizeState,
   } = props;
 
   const applyStyle = useApplyStyle('Stage/TextBox/textbox.scss');
@@ -175,7 +177,6 @@ export default function IMSSTextbox(props: ITextboxProps) {
           wordBreak: isSafari || props.isFirefox ? 'break-all' : undefined,
           display: isSafari ? 'flex' : undefined,
           flexWrap: isSafari ? 'wrap' : undefined,
-          height: '2.2em', //这里是为了让每一行都有一个固定的高度，不然会出现高度不一致的情况
         }}
         key={`text-line-${index}`}
       >
@@ -252,7 +253,7 @@ export default function IMSSTextbox(props: ITextboxProps) {
                 flexFlow: 'column',
                 overflow: 'hidden',
                 paddingLeft: '0.1em',
-                lineHeight: '3em', //不加的话上半拼音可能会被截断，同时保持排版整齐
+                lineHeight: textSizeState === textSize.medium ? '2.2em' : '2em', // 不加的话上半拼音可能会被截断，同时保持排版整齐
               }}
             >
               {textElementList}

--- a/packages/webgal/src/Stage/TextBox/IMSSTextbox.tsx
+++ b/packages/webgal/src/Stage/TextBox/IMSSTextbox.tsx
@@ -175,6 +175,7 @@ export default function IMSSTextbox(props: ITextboxProps) {
           wordBreak: isSafari || props.isFirefox ? 'break-all' : undefined,
           display: isSafari ? 'flex' : undefined,
           flexWrap: isSafari ? 'wrap' : undefined,
+          height: '2.2em', //这里是为了让每一行都有一个固定的高度，不然会出现高度不一致的情况
         }}
         key={`text-line-${index}`}
       >
@@ -251,6 +252,7 @@ export default function IMSSTextbox(props: ITextboxProps) {
                 flexFlow: 'column',
                 overflow: 'hidden',
                 paddingLeft: '0.1em',
+                lineHeight: '3em', //不加的话上半拼音可能会被截断，同时保持排版整齐
               }}
             >
               {textElementList}

--- a/packages/webgal/src/Stage/TextBox/TextBox.tsx
+++ b/packages/webgal/src/Stage/TextBox/TextBox.tsx
@@ -60,7 +60,7 @@ export const TextBox = () => {
     size = getTextSize(stageState.showTextSize) + '%';
     textSizeState = stageState.showTextSize;
   }
-  const lineLimit = match(userDataState.optionData.textSize)
+  const lineLimit = match(textSizeState)
     .with(textSize.small, () => 3)
     .with(textSize.medium, () => 2)
     .with(textSize.large, () => 2)

--- a/packages/webgal/src/Stage/TextBox/textbox.module.scss
+++ b/packages/webgal/src/Stage/TextBox/textbox.module.scss
@@ -71,6 +71,8 @@ $height: 330px;
   position: relative;
   animation: TextDelayShow 1000ms ease-out forwards;
   opacity: 0;
+  display: inline-flex;
+  align-content: space-between
 }
 
 

--- a/packages/webgal/src/Stage/TextBox/textbox.module.scss
+++ b/packages/webgal/src/Stage/TextBox/textbox.module.scss
@@ -73,11 +73,10 @@ $height: 330px;
   opacity: 0;
 }
 
+
 .outer {
   position: absolute;
   white-space: nowrap;
-  left: 0;
-  top: 0;
   //background-image: linear-gradient(rgba(255, 255, 255, 1) 0%, rgb(225, 237, 255) 100%);
   background-image: linear-gradient(#0B346E 0%,
     //#f5f7fa 45%,
@@ -87,21 +86,26 @@ $height: 330px;
   -webkit-background-clip: text;
   color: transparent;
   z-index: 2;
+  display: inline-block;   /* 与文本对齐 */
+  vertical-align: middle;  /* 确保注音整体的垂直居中 */
 }
 
 .inner {
   white-space: nowrap;
   position: absolute;
-  left: 0;
-  top: 0;
   -webkit-text-stroke: 0.1em rgba(255, 255, 255, 1);
   z-index: 1;
   //text-shadow: 2px 2px 5px rgba(0, 0, 0, 0.75);
+  display: inline-block;   /* 内层元素同样行内块布局 */
+  vertical-align: middle;  /* 确保与外层的对齐一致 */
 }
 
 .zhanwei {
   color: transparent;
   white-space: nowrap;
+  display: inline-block;    /* 保持行内块布局 */
+  vertical-align: baseline; /* 确保文本基线对齐 */
+  position: relative;       /* 保持相对定位 */
 }
 
 //
@@ -116,6 +120,8 @@ $height: 330px;
   position: relative;
   @include text_shadow_textElement;
   opacity: 1;
+  display: inline-flex;
+  align-content: space-between
 }
 
 //

--- a/packages/webgal/src/UI/getTextSize.ts
+++ b/packages/webgal/src/UI/getTextSize.ts
@@ -1,11 +1,11 @@
 export function getTextSize(size: number) {
   switch (size) {
     case 0:
-      return 150;
+      return 155;
     case 1:
       return 205;
     case 2:
-      return 240;
+      return 230;
     default:
       return 205;
   }


### PR DESCRIPTION
# 摘要
**不涉及任何逻辑，只修改了排版**
1.把所有字都向下对齐
2.固定行距保证无论这行有没有拼音都会显示在同样的高度
![)%U`4EXF~1`(A6JJ(YJN5SF](https://github.com/user-attachments/assets/f4d4c54d-ca3b-4ad8-96cf-3c763dfc2240)

# 对比原本效果
## before
- 大：
![图片](https://github.com/user-attachments/assets/9b8517e0-1ae5-452e-8527-e4b1e80fc6ed)
- 中：
![图片](https://github.com/user-attachments/assets/cdcb78db-40dd-49d9-a957-c5f47e00c008)
- 小：
![图片](https://github.com/user-attachments/assets/730c3b3d-3638-48b8-b77c-1241b3e4fba9)


## after
- 大：
![图片](https://github.com/user-attachments/assets/a73d0aa9-0596-4a44-89ff-5b668c7a05b1)
- 中：
![图片](https://github.com/user-attachments/assets/368ac147-e631-47ac-89f2-0d003aae5139)
- 小：
![图片](https://github.com/user-attachments/assets/e768e60a-40ce-40cf-a972-93a61bf5dd54)


# 对于旧代码
只修改了必须求改的部分，并做了解释。

# P.S.
大字体那里确实没办法改了，所以选择了保持原状
