### PR TITLE
intro 不自动步进，点击一次出现一行

### DIFF
--- a/packages/webgal/src/Core/constants.ts
+++ b/packages/webgal/src/Core/constants.ts
@@ -6,3 +6,4 @@ export const STAGE_KEYS = {
 };
 
 export const WEBGAL_NONE = 'none';
+export const TIME_AS_INFINITY = 1000 * 60 * 60 * 24;

--- a/packages/webgal/src/Core/gameScripts/choose/index.tsx
+++ b/packages/webgal/src/Core/gameScripts/choose/index.tsx
@@ -14,6 +14,7 @@ import { whenChecker } from '@/Core/controller/gamePlay/scriptExecutor';
 import useEscape from '@/hooks/useEscape';
 import useApplyStyle from '@/hooks/useApplyStyle';
 import { Provider } from 'react-redux';
+import {TIME_AS_INFINITY} from "@/Core/constants";
 
 class ChooseOption {
   /**
@@ -68,7 +69,7 @@ export const choose = (sentence: ISentence): IPerform => {
   );
   return {
     performName: 'choose',
-    duration: 1000 * 60 * 60 * 24,
+    duration: TIME_AS_INFINITY,
     isHoldOn: false,
     stopFunction: () => {
       // eslint-disable-next-line react/no-deprecated

--- a/packages/webgal/src/Core/gameScripts/getUserInput/index.tsx
+++ b/packages/webgal/src/Core/gameScripts/getUserInput/index.tsx
@@ -13,6 +13,7 @@ import { WebGAL } from '@/Core/WebGAL';
 import { getSentenceArgByKey } from '@/Core/util/getSentenceArg';
 import { nextSentence } from '@/Core/controller/gamePlay/nextSentence';
 import { setStageVar } from '@/store/stageReducer';
+import {TIME_AS_INFINITY} from "@/Core/constants";
 
 /**
  * 显示选择枝
@@ -59,7 +60,7 @@ export const getUserInput = (sentence: ISentence): IPerform => {
   );
   return {
     performName: 'userInput',
-    duration: 1000 * 60 * 60 * 24,
+    duration: TIME_AS_INFINITY,
     isHoldOn: false,
     stopFunction: () => {
       // eslint-disable-next-line react/no-deprecated

--- a/packages/webgal/src/Core/gameScripts/intro.tsx
+++ b/packages/webgal/src/Core/gameScripts/intro.tsx
@@ -9,6 +9,7 @@ import { logger } from '@/Core/util/logger';
 import { WebGAL } from '@/Core/WebGAL';
 import { replace } from 'lodash';
 import useEscape from '@/hooks/useEscape';
+import {TIME_AS_INFINITY} from "@/Core/constants";
 /**
  * 显示一小段黑屏演示
  * @param sentence
@@ -69,6 +70,9 @@ export const intro = (sentence: ISentence): IPerform => {
       const parsedValue = parseInt(e.value.toString(), 10);
       delayTime = isNaN(parsedValue) ? delayTime : parsedValue;
     }
+    if (e.key === 'delayTimeInfinity') {
+      delayTime = TIME_AS_INFINITY;
+    }
     if (e.key === 'hold') {
       if (e.value === true) {
         isHold = true;
@@ -87,7 +91,7 @@ export const intro = (sentence: ISentence): IPerform => {
 
   let endWait = 1000;
   let baseDuration = endWait + delayTime * introArray.length;
-  const duration = isHold ? 1000 * 60 * 60 * 24 : 1000 + delayTime * introArray.length;
+  const duration = isHold ? TIME_AS_INFINITY : (endWait + delayTime * introArray.length);
   let isBlocking = true;
   let setBlockingStateTimeout = setTimeout(() => {
     isBlocking = false;
@@ -112,6 +116,7 @@ export const intro = (sentence: ISentence): IPerform => {
         if (currentDelay > 0) {
           node.style.animationDelay = `${currentDelay - delayTime}ms`;
         }
+        logger.info(`children${index}，animationDelay更新：${currentDelay} -> ${node.style.animationDelay}`);
         // 最后一个元素了
         if (index === len - 1) {
           // 并且已经完全显示了，这时候进行下一步


### PR DESCRIPTION
现有功能已经是点击一次出现一行（点击一次令动画提前一个delayTime长度），只不过默认delayTime=1500较短，不易看出此特性。

测试用例：

```
intro:第1行|第2行|第3行 -delayTimeInfinity;
或
intro:第1行|第2行|第3行 -delayTime=9999;
```

### 待讨论：
- [ ] 考虑到保持行为不变，则默认delayTime=1500不变。新增delayTimeInfinity使得delayTime变为无穷，
- [ ] 当delayTime变长甚至无穷时，首行出现前的延时/最后一行后的延时，也值得讨论。目前预期行为不确定?

### changes：
- 用常数代表无限延时时长: 避免多处使用魔法值
- intro新增delayTimeInfinity: 可讨论是否用别的语法