### PR TITLE
feat: Rename "中文" to "简体中文" for better clarity

### DIFF
--- a/packages/webgal/src/config/language.ts
+++ b/packages/webgal/src/config/language.ts
@@ -27,7 +27,7 @@ export enum language {
 }
 
 const languages: Record<string, string> = {
-  zhCn: '中文',
+  zhCn: '简体中文',
   en: 'English',
   jp: '日本語',
   fr: 'Français',


### PR DESCRIPTION
针对 Issue #600
根据反馈，将语言选项中的“中文”更新为“简体中文”，以减少繁体中文用户的混淆，并提升用户体验。