### PR TITLE
fix: backlog record async

### DIFF
--- a/packages/webgal/src/Core/controller/gamePlay/scriptExecutor.ts
+++ b/packages/webgal/src/Core/controller/gamePlay/scriptExecutor.ts
@@ -12,6 +12,7 @@ import { ISceneEntry } from '@/Core/Modules/scene';
 import { IBacklogItem } from '@/Core/Modules/backlog';
 import { SYSTEM_CONFIG } from '@/config';
 import { WebGAL } from '@/Core/WebGAL';
+import {callBackFunctionOfUpdate, updateFigureFlag, useSetFigure} from "@/Stage/MainStage/useSetFigure";
 
 export const whenChecker = (whenValue: string | undefined): boolean => {
   if (whenValue === undefined) {
@@ -150,7 +151,10 @@ export const scriptExecutor = () => {
     // 保存 backlog
     if (isSaveBacklog) {
       // WebGAL.backlogManager.isSaveBacklogNext = true;
-      WebGAL.backlogManager.saveCurrentStateToBacklog();
+      const saveFunction = () => WebGAL.backlogManager.saveCurrentStateToBacklog();
+      if (updateFigureFlag) {
+        callBackFunctionOfUpdate.push(saveFunction);
+      } else saveFunction();
     }
   }, 0);
   WebGAL.sceneManager.sceneData.currentSentenceId++;

--- a/packages/webgal/src/Stage/MainStage/useSetFigure.ts
+++ b/packages/webgal/src/Stage/MainStage/useSetFigure.ts
@@ -8,6 +8,9 @@ import { generateUniversalSoftOffAnimationObj } from '@/Core/controller/stage/pi
 import { getEnterExitAnimation } from '@/Core/Modules/animationFunctions';
 import { WebGAL } from '@/Core/WebGAL';
 
+export let updateFigureFlag = false;
+export const callBackFunctionOfUpdate: Function[] = [];
+
 export function useSetFigure(stageState: IStageState) {
   const { figNameLeft, figName, figNameRight, freeFigure, live2dMotion, live2dExpression } = stageState;
 
@@ -49,7 +52,7 @@ export function useSetFigure(stageState: IStageState) {
       logger.debug('中立绘已重设');
       const { duration, animation } = getEnterExitAnimation(thisFigKey, 'enter');
       WebGAL.gameplay.pixiStage!.registerPresetAnimation(animation, softInAniKey, thisFigKey, stageState.effects);
-      setTimeout(() => WebGAL.gameplay.pixiStage!.removeAnimationWithSetEffects(softInAniKey), duration);
+      updateFigureToRemoveAnimationWithSetEffects(softInAniKey, duration);
     } else {
       logger.debug('移除中立绘');
       const currentFigCenter = WebGAL.gameplay.pixiStage?.getStageObjByKey(thisFigKey);
@@ -60,6 +63,18 @@ export function useSetFigure(stageState: IStageState) {
       }
     }
   }, [figName]);
+
+  const updateFigureToRemoveAnimationWithSetEffects = (softInAniKey: string, duration: number) => {
+    updateFigureFlag = true;
+    setTimeout(() => {
+      WebGAL.gameplay.pixiStage!.removeAnimationWithSetEffects(softInAniKey);
+      while (callBackFunctionOfUpdate.length) {
+        const fun = callBackFunctionOfUpdate.shift();
+        fun?.();
+      }
+      updateFigureFlag = false;
+    }, duration);
+  };
 
   useEffect(() => {
     /**
@@ -78,7 +93,7 @@ export function useSetFigure(stageState: IStageState) {
       logger.debug('左立绘已重设');
       const { duration, animation } = getEnterExitAnimation(thisFigKey, 'enter');
       WebGAL.gameplay.pixiStage!.registerPresetAnimation(animation, softInAniKey, thisFigKey, stageState.effects);
-      setTimeout(() => WebGAL.gameplay.pixiStage!.removeAnimationWithSetEffects(softInAniKey), duration);
+      updateFigureToRemoveAnimationWithSetEffects(softInAniKey, duration);
     } else {
       logger.debug('移除左立绘');
       const currentFigLeft = WebGAL.gameplay.pixiStage?.getStageObjByKey(thisFigKey);
@@ -107,7 +122,7 @@ export function useSetFigure(stageState: IStageState) {
       logger.debug('右立绘已重设');
       const { duration, animation } = getEnterExitAnimation(thisFigKey, 'enter');
       WebGAL.gameplay.pixiStage!.registerPresetAnimation(animation, softInAniKey, thisFigKey, stageState.effects);
-      setTimeout(() => WebGAL.gameplay.pixiStage!.removeAnimationWithSetEffects(softInAniKey), duration);
+      updateFigureToRemoveAnimationWithSetEffects(softInAniKey, duration);
     } else {
       const currentFigRight = WebGAL.gameplay.pixiStage?.getStageObjByKey(thisFigKey);
       if (currentFigRight) {
@@ -138,14 +153,14 @@ export function useSetFigure(stageState: IStageState) {
             logger.debug(`${fig.key}立绘已重设`);
             const { duration, animation } = getEnterExitAnimation(thisFigKey, 'enter');
             WebGAL.gameplay.pixiStage!.registerPresetAnimation(animation, softInAniKey, thisFigKey, stageState.effects);
-            setTimeout(() => WebGAL.gameplay.pixiStage!.removeAnimationWithSetEffects(softInAniKey), duration);
+            updateFigureToRemoveAnimationWithSetEffects(softInAniKey, duration);
           }
         } else {
           addFigure(undefined, thisFigKey, fig.name, fig.basePosition);
           logger.debug(`${fig.key}立绘已重设`);
           const { duration, animation } = getEnterExitAnimation(thisFigKey, 'enter');
           WebGAL.gameplay.pixiStage!.registerPresetAnimation(animation, softInAniKey, thisFigKey, stageState.effects);
-          setTimeout(() => WebGAL.gameplay.pixiStage!.removeAnimationWithSetEffects(softInAniKey), duration);
+          updateFigureToRemoveAnimationWithSetEffects(softInAniKey, duration);
         }
       } else {
         const currentFigThisKey = WebGAL.gameplay.pixiStage?.getStageObjByKey(thisFigKey);


### PR DESCRIPTION
发生于以下Scene：
1. 任意语句X(带 -next)：
2. Say
导致2.记录的Backlog不包括X的动作后续Effect的更新
