### PR TITLE
Fix color adjustment animation missing

### DIFF
--- a/packages/webgal/src/store/stageInterface.ts
+++ b/packages/webgal/src/store/stageInterface.ts
@@ -39,6 +39,13 @@ export interface ITransform {
   };
   rotation: number;
   blur: number;
+  brightness: number;
+  contrast: number;
+  saturation: number;
+  gamma: number;
+  colorRed: number;
+  colorGreen: number;
+  colorBlue: number;
 }
 
 /**
@@ -69,6 +76,13 @@ export const baseTransform: ITransform = {
   },
   rotation: 0,
   blur: 0,
+  brightness: 1,
+  contrast: 1,
+  saturation: 1,
+  gamma: 1,
+  colorRed: 255,
+  colorGreen: 255,
+  colorBlue: 255,
 };
 
 export interface IFreeFigure {


### PR DESCRIPTION
# 介绍
根据测试，若 `ITransform` 中缺少相关属性，会导致 _第一次_ 设置该属性的动画时，动画会消失；

# 主要更改
- 在 `ITransform` 中添加 __颜色调整__ 相关属性

# 测试
```js
changeBg: bg.png -next;
changeFigure: stand.png -id=aaa -next;
测试对话: 入场，无 Transform 数据;
setTransform: {"brightness":0.5} -target=aaa -next;
测试对话: 设置亮度为0.5, 动画有突变;
setTransform: {"brightness":1} -target=aaa -next;
测试对话: 设置亮度为1, 动画正常;
```