### PR TITLE
feat: add exit button

### DIFF
--- a/packages/webgal/src/UI/Title/Title.tsx
+++ b/packages/webgal/src/UI/Title/Title.tsx
@@ -117,6 +117,16 @@ const Title: FC = () => {
                 <div className={applyStyle('Title_button_text', styles.Title_button_text)}>{t('extra.title')}</div>
               </div>
             )}
+            <div
+              className={applyStyle('Title_button', styles.Title_button)}
+              onClick={() => {
+                playSeClick();
+                window.close();
+              }}
+              onMouseEnter={playSeEnter}
+            >
+              <div className={applyStyle('Title_button_text', styles.Title_button_text)}>{t('exit.title')}</div>
+            </div>
           </div>
         </div>
       )}

--- a/packages/webgal/src/translations/de.ts
+++ b/packages/webgal/src/translations/de.ts
@@ -149,6 +149,10 @@ const de = {
       title: 'EXTRA',
       subtitle: '',
     },
+    exit: {
+      title: 'BEENDEN',
+      subtitle: '',
+    },
   },
 
   gaming: {

--- a/packages/webgal/src/translations/en.ts
+++ b/packages/webgal/src/translations/en.ts
@@ -156,6 +156,10 @@ const en = {
       title: 'EXTRA',
       subtitle: '',
     },
+    exit: {
+      title: 'EXIT',
+      subtitle: '',
+    },
   },
 
   gaming: {

--- a/packages/webgal/src/translations/fr.ts
+++ b/packages/webgal/src/translations/fr.ts
@@ -149,6 +149,10 @@ const fr = {
       title: 'EXTRA',
       subtitle: '',
     },
+    exit: {
+      title: 'QUITTER',
+      subtitle: '',
+    },
   },
 
   gaming: {

--- a/packages/webgal/src/translations/jp.ts
+++ b/packages/webgal/src/translations/jp.ts
@@ -159,6 +159,10 @@ const jp = {
       title: '鑑賞モード',
       subtitle: 'EXTRA',
     },
+    exit: {
+      title: 'ゲーム終了',
+      subtitle: 'EXIT',
+    },
   },
 
   gaming: {

--- a/packages/webgal/src/translations/zh-cn.ts
+++ b/packages/webgal/src/translations/zh-cn.ts
@@ -163,6 +163,10 @@ const zhCn = {
       title: '鉴赏模式',
       subtitle: 'EXTRA',
     },
+    exit: {
+      title: '退出游戏',
+      subtitle: 'EXIT',
+    },
   },
 
   gaming: {

--- a/packages/webgal/src/translations/zh-tw.ts
+++ b/packages/webgal/src/translations/zh-tw.ts
@@ -163,6 +163,10 @@ const zhTw = {
       title: 'CG模式',
       subtitle: 'EXTRA',
     },
+    exit: {
+      title: '退出遊戲',
+      subtitle: 'EXIT',
+    },
   },
 
   gaming: {


### PR DESCRIPTION
此pr 添加了退出游戏的按钮，在网页上使用`window.close`，将会关闭当前游戏标签页。

在electron中，结合[feat: add close event ](https://github.com/OpenWebGAL/WebGAL_Terre/pull/410)  此PR可实现在桌面端关闭游戏。

![image](https://github.com/user-attachments/assets/d927e25e-3412-4575-b0ff-59a3d9659aef)
