### PR TITLE
fix: figure initial position

### DIFF
--- a/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
@@ -563,7 +563,7 @@ export default class PixiStage {
           const targetHeight = originalHeight * targetScale;
           thisFigureContainer.setBaseY(this.stageHeight / 2);
           if (targetHeight < this.stageHeight) {
-            thisFigureContainer.setBaseY(this.stageHeight / 2 + this.stageHeight - targetHeight / 2);
+            thisFigureContainer.setBaseY(this.stageHeight / 2 + (this.stageHeight - targetHeight) / 2);
           }
           if (presetPosition === 'center') {
             thisFigureContainer.setBaseX(this.stageWidth / 2);
@@ -673,7 +673,7 @@ export default class PixiStage {
 
               let baseY = stageHeight / 2;
               if (targetHeight < stageHeight) {
-                baseY = stageHeight / 2 + stageHeight - targetHeight / 2;
+                baseY = stageHeight / 2 + (stageHeight - targetHeight) / 2;
               }
               thisFigureContainer.setBaseY(baseY);
               if (pos === 'center') {

--- a/packages/webgal/src/Core/controller/stage/pixi/spine.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/spine.ts
@@ -126,7 +126,7 @@ export async function addSpineFigureImpl(
       const targetHeight = originalHeight * targetScale;
       thisFigureContainer.setBaseY(this.stageHeight / 2);
       if (targetHeight < this.stageHeight) {
-        thisFigureContainer.setBaseY(this.stageHeight / 2 + this.stageHeight - targetHeight / 2);
+        thisFigureContainer.setBaseY(this.stageHeight / 2 + (this.stageHeight - targetHeight) / 2);
       }
       if (presetPosition === 'center') {
         thisFigureContainer.setBaseX(this.stageWidth / 2);


### PR DESCRIPTION
# 介绍
修复宽高比宽于画布的立绘的初始定位问题，应该能 close #685 

# 复现
新建一个测试工程，下载这两张图片到Figure目录里

<table>
   <tr>
    <td align="center">宽于16比9.png</td>
    <td align="center">宽于16比9.png</td>
  </tr>
  <tr>
    <td align="center"><img src="https://github.com/user-attachments/assets/0deaee20-9b95-44d5-b569-662061637f6d" width="100%"/></td>
    <td align="center"><img src="https://github.com/user-attachments/assets/d38d9ac9-4254-4820-8bb3-d899133a539f" width="100%"/></td>
  </tr>
</table>

新建一个txt，并粘贴如下代码
```js
changeFigure: 宽于16比9.png -transform={"alpha":0.5} -id=aaa -next;
changeFigure: 窄于16比9.png -transform={"alpha":0.5} -id=bbb -next;
:;
```

应当能看到以下区别

<table>
   <tr>
    <td align="center">Before</td>
    <td align="center">After</td>
  </tr>
  <tr>
    <td align="center"><img src="https://github.com/user-attachments/assets/3e32a791-9b65-4f8f-9678-040048d58461" width="100%"/></td>
    <td align="center"><img src="https://github.com/user-attachments/assets/9c851b98-c2f6-47ce-9618-b6b7517f0643" width="100%"/></td>
  </tr>
</table>