### PR TITLE
Fix: Enable Character-by-Character Animation for Styled Text

### DIFF
--- a/packages/webgal/src/Stage/TextBox/TextBox.tsx
+++ b/packages/webgal/src/Stage/TextBox/TextBox.tsx
@@ -138,15 +138,20 @@ export function compileSentence(
         })
         .endsWith(SegmentType.Link, () => {
           const val = node.value as EnhancedValue;
-          const enhancedNode = (
-            <span className="__enhanced_text" key={val.text + `${index}`}>
-              <ruby key={index + val.text}>
-                {val.text}
-                <rt>{val.ruby}</rt>
-              </ruby>
-            </span>
-          );
-          ln.push({ reactNode: enhancedNode, enhancedValue: val.values });
+          // 将带样式的文本也拆分成单个字符
+          const chars = splitChars(val.text, replace_space_with_nbsp);
+          // eslint-disable-next-line max-nested-callbacks
+          chars.forEach((char, charIndex) => {
+            const enhancedNode = (
+              <span className="__enhanced_text" key={val.text + `${index}-${charIndex}`}>
+                <ruby key={index + val.text + charIndex}>
+                  {char}
+                  <rt>{val.ruby}</rt>
+                </ruby>
+              </span>
+            );
+            ln.push({ reactNode: enhancedNode, enhancedValue: val.values });
+          });
         });
     });
     return ln;

--- a/packages/webgal/src/Stage/TextBox/TextBox.tsx
+++ b/packages/webgal/src/Stage/TextBox/TextBox.tsx
@@ -138,20 +138,31 @@ export function compileSentence(
         })
         .endsWith(SegmentType.Link, () => {
           const val = node.value as EnhancedValue;
-          // 将带样式的文本也拆分成单个字符
-          const chars = splitChars(val.text, replace_space_with_nbsp);
-          // eslint-disable-next-line max-nested-callbacks
-          chars.forEach((char, charIndex) => {
+          // 检查是否是注音文本（通过检查是否有ruby值）
+          if (val.ruby) {
+            // 注音文本作为整体处理
             const enhancedNode = (
-              <span className="__enhanced_text" key={val.text + `${index}-${charIndex}`}>
-                <ruby key={index + val.text + charIndex}>
-                  {char}
+              <span className="__enhanced_text" key={val.text + `${index}`}>
+                <ruby key={index + val.text}>
+                  {val.text}
                   <rt>{val.ruby}</rt>
                 </ruby>
               </span>
             );
             ln.push({ reactNode: enhancedNode, enhancedValue: val.values });
-          });
+          } else {
+            // 样式文本逐字处理
+            const chars = splitChars(val.text, replace_space_with_nbsp);
+            // eslint-disable-next-line max-nested-callbacks
+            chars.forEach((char, charIndex) => {
+              const enhancedNode = (
+                <span className="__enhanced_text" key={val.text + `${index}-${charIndex}`}>
+                  {char}
+                </span>
+              );
+              ln.push({ reactNode: enhancedNode, enhancedValue: val.values });
+            });
+          }
         });
     });
     return ln;


### PR DESCRIPTION
## Description
This PR fixes an issue where text with styles (e.g., `[text](style=color:#FF0000)`) would appear all at once instead of character-by-character like plain text.

### before

![demo1](https://github.com/user-attachments/assets/3110abdf-1f4d-432b-ae22-30139e9804f0)

### after

![demo2](https://github.com/user-attachments/assets/7e23f116-e0ed-4754-82e1-5db2300f207a)

## Changes
- Modified `compileSentence` function to split styled text into individual characters
- Preserved style and ruby annotations for each character
- Ensured consistent animation behavior across all text types

## Testing
Please test the following scenarios:
1. Plain text animation
2. Text with styles (e.g., `[text](style=color:#FF0000)`)
3. Text with ruby annotations
4. Mixed content with both styled and plain text