### PR TITLE
Fix missing enter animation

### DIFF
--- a/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
@@ -36,6 +36,8 @@ export interface IStageObject {
   // 一般与作用目标有关
   key: string;
   pixiContainer: WebGALPixiContainer;
+  // 不需要执行 onLoaded 函数
+  ignoreOnLoaded: boolean;
   // 相关的源 url
   sourceUrl: string;
   sourceExt: string;
@@ -193,6 +195,10 @@ export default class PixiStage {
   public registerAnimation(animationObject: IAnimationObject | null, key: string, target = 'default') {
     if (!animationObject) return;
     this.stageAnimations.push({ uuid: uuid(), animationObject, key: key, targetKey: target, type: 'common' });
+    const stageObject = this.getStageObjByKey(target);
+    if (stageObject) {
+      stageObject.ignoreOnLoaded = true;
+    }
     // 上锁
     this.lockStageObject(target);
     animationObject.setStartState();
@@ -224,6 +230,10 @@ export default class PixiStage {
       return;
     }
     this.stageAnimations.push({ uuid: uuid(), animationObject, key: key, targetKey: target, type: 'preset' });
+    const stageObject = this.getStageObjByKey(target);
+    if (stageObject) {
+      stageObject.ignoreOnLoaded = true;
+    }
     // 上锁
     this.lockStageObject(target);
     animationObject.setStartState();
@@ -376,14 +386,16 @@ export default class PixiStage {
     // 挂载
     this.backgroundContainer.addChild(thisBgContainer);
     const bgUuid = uuid();
-    this.backgroundObjects.push({
+    const stageObject: IStageObject = {
       uuid: bgUuid,
       key: key,
       pixiContainer: thisBgContainer,
+      ignoreOnLoaded: false,
       sourceUrl: url,
       sourceType: 'img',
       sourceExt: this.getExtName(url),
-    });
+    };
+    this.backgroundObjects.push(stageObject);
 
     // 完成图片加载后执行的函数
     const setup = () => {
@@ -409,7 +421,9 @@ export default class PixiStage {
         // 挂载
         thisBgContainer.addChild(bgSprite);
       }
-      onLoaded();
+      if (!stageObject.ignoreOnLoaded) {
+        onLoaded();
+      }
     };
 
     /**
@@ -447,14 +461,16 @@ export default class PixiStage {
     // 挂载
     this.backgroundContainer.addChild(thisBgContainer);
     const bgUuid = uuid();
-    this.backgroundObjects.push({
+    const stageObject: IStageObject = {
       uuid: bgUuid,
       key: key,
       pixiContainer: thisBgContainer,
+      ignoreOnLoaded: false,
       sourceUrl: url,
       sourceType: 'video',
       sourceExt: this.getExtName(url),
-    });
+    };
+    this.backgroundObjects.push(stageObject);
 
     // 完成加载后执行的函数
     const setup = () => {
@@ -490,7 +506,9 @@ export default class PixiStage {
           thisBgContainer.addChild(bgSprite);
         });
       }
-      onLoaded();
+      if (!stageObject.ignoreOnLoaded) {
+        onLoaded();
+      }
     };
 
     /**
@@ -534,14 +552,16 @@ export default class PixiStage {
     // 挂载
     this.figureContainer.addChild(thisFigureContainer);
     const figureUuid = uuid();
-    this.figureObjects.push({
+    const stageObject: IStageObject = {
       uuid: figureUuid,
       key: key,
       pixiContainer: thisFigureContainer,
+      ignoreOnLoaded: false,
       sourceUrl: url,
       sourceType: 'img',
       sourceExt: this.getExtName(url),
-    });
+    };
+    this.figureObjects.push(stageObject);
 
     // 完成图片加载后执行的函数
     const setup = () => {
@@ -578,7 +598,9 @@ export default class PixiStage {
         thisFigureContainer.pivot.set(0, this.stageHeight / 2);
         thisFigureContainer.addChild(figureSprite);
       }
-      onLoaded();
+      if (!stageObject.ignoreOnLoaded) {
+        onLoaded();
+      }
     };
 
     /**
@@ -629,14 +651,16 @@ export default class PixiStage {
       // 挂载
       this.figureContainer.addChild(thisFigureContainer);
       const figureUuid = uuid();
-      this.figureObjects.push({
+      const stageObject: IStageObject = {
         uuid: figureUuid,
         key: key,
         pixiContainer: thisFigureContainer,
+        ignoreOnLoaded: false,
         sourceUrl: jsonPath,
         sourceType: 'live2d',
         sourceExt: 'json',
-      });
+      };
+      this.figureObjects.push(stageObject);
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       const instance = this;
 
@@ -725,7 +749,9 @@ export default class PixiStage {
             });
           })();
         }
-        onLoaded();
+        if (!stageObject.ignoreOnLoaded) {
+          onLoaded();
+        }
       };
 
       /**

--- a/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
@@ -357,7 +357,7 @@ export default class PixiStage {
    * @param key 背景的标识，一般和背景类型有关
    * @param url 背景图片url
    */
-  public addBg(key: string, url: string) {
+  public addBg(onLoaded: () => void, key: string, url: string) {
     // const loader = this.assetLoader;
     const loader = this.assetLoader;
     // 准备用于存放这个背景的 Container
@@ -387,32 +387,29 @@ export default class PixiStage {
 
     // 完成图片加载后执行的函数
     const setup = () => {
-      // TODO：找一个更好的解法，现在的解法是无论是否复用原来的资源，都设置一个延时以让动画工作正常！
+      const texture = loader.resources?.[url]?.texture;
+      if (texture && this.getStageObjByUuid(bgUuid)) {
+        /**
+         * 重设大小
+         */
+        const originalWidth = texture.width;
+        const originalHeight = texture.height;
+        const scaleX = this.stageWidth / originalWidth;
+        const scaleY = this.stageHeight / originalHeight;
+        const targetScale = Math.max(scaleX, scaleY);
+        const bgSprite = new PIXI.Sprite(texture);
+        bgSprite.scale.x = targetScale;
+        bgSprite.scale.y = targetScale;
+        bgSprite.anchor.set(0.5);
+        bgSprite.position.y = this.stageHeight / 2;
+        thisBgContainer.setBaseX(this.stageWidth / 2);
+        thisBgContainer.setBaseY(this.stageHeight / 2);
+        thisBgContainer.pivot.set(0, this.stageHeight / 2);
 
-      setTimeout(() => {
-        const texture = loader.resources?.[url]?.texture;
-        if (texture && this.getStageObjByUuid(bgUuid)) {
-          /**
-           * 重设大小
-           */
-          const originalWidth = texture.width;
-          const originalHeight = texture.height;
-          const scaleX = this.stageWidth / originalWidth;
-          const scaleY = this.stageHeight / originalHeight;
-          const targetScale = Math.max(scaleX, scaleY);
-          const bgSprite = new PIXI.Sprite(texture);
-          bgSprite.scale.x = targetScale;
-          bgSprite.scale.y = targetScale;
-          bgSprite.anchor.set(0.5);
-          bgSprite.position.y = this.stageHeight / 2;
-          thisBgContainer.setBaseX(this.stageWidth / 2);
-          thisBgContainer.setBaseY(this.stageHeight / 2);
-          thisBgContainer.pivot.set(0, this.stageHeight / 2);
-
-          // 挂载
-          thisBgContainer.addChild(bgSprite);
-        }
-      }, 0);
+        // 挂载
+        thisBgContainer.addChild(bgSprite);
+      }
+      onLoaded();
     };
 
     /**
@@ -432,7 +429,7 @@ export default class PixiStage {
    * @param key 背景的标识，一般和背景类型有关
    * @param url 背景图片url
    */
-  public addVideoBg(key: string, url: string) {
+  public addVideoBg(onLoaded: () => void, key: string, url: string) {
     const loader = this.assetLoader;
     // 准备用于存放这个背景的 Container
     const thisBgContainer = new WebGALPixiContainer();
@@ -461,42 +458,39 @@ export default class PixiStage {
 
     // 完成加载后执行的函数
     const setup = () => {
-      // TODO：找一个更好的解法，现在的解法是无论是否复用原来的资源，都设置一个延时以让动画工作正常！
-
-      setTimeout(() => {
-        console.debug('start loaded video: ' + url);
-        const video = document.createElement('video');
-        const videoResource = new PIXI.VideoResource(video);
-        videoResource.src = url;
-        videoResource.source.preload = 'auto';
-        videoResource.source.muted = true;
-        videoResource.source.loop = true;
-        videoResource.source.autoplay = true;
-        videoResource.source.src = url;
-        // @ts-ignore
-        const texture = PIXI.Texture.from(videoResource);
-        if (texture && this.getStageObjByUuid(bgUuid)) {
-          /**
-           * 重设大小
-           */
-          texture.baseTexture.resource.load().then(() => {
-            const originalWidth = videoResource.source.videoWidth;
-            const originalHeight = videoResource.source.videoHeight;
-            const scaleX = this.stageWidth / originalWidth;
-            const scaleY = this.stageHeight / originalHeight;
-            const targetScale = Math.max(scaleX, scaleY);
-            const bgSprite = new PIXI.Sprite(texture);
-            bgSprite.scale.x = targetScale;
-            bgSprite.scale.y = targetScale;
-            bgSprite.anchor.set(0.5);
-            bgSprite.position.y = this.stageHeight / 2;
-            thisBgContainer.setBaseX(this.stageWidth / 2);
-            thisBgContainer.setBaseY(this.stageHeight / 2);
-            thisBgContainer.pivot.set(0, this.stageHeight / 2);
-            thisBgContainer.addChild(bgSprite);
-          });
-        }
-      }, 0);
+      console.debug('start loaded video: ' + url);
+      const video = document.createElement('video');
+      const videoResource = new PIXI.VideoResource(video);
+      videoResource.src = url;
+      videoResource.source.preload = 'auto';
+      videoResource.source.muted = true;
+      videoResource.source.loop = true;
+      videoResource.source.autoplay = true;
+      videoResource.source.src = url;
+      // @ts-ignore
+      const texture = PIXI.Texture.from(videoResource);
+      if (texture && this.getStageObjByUuid(bgUuid)) {
+        /**
+         * 重设大小
+         */
+        texture.baseTexture.resource.load().then(() => {
+          const originalWidth = videoResource.source.videoWidth;
+          const originalHeight = videoResource.source.videoHeight;
+          const scaleX = this.stageWidth / originalWidth;
+          const scaleY = this.stageHeight / originalHeight;
+          const targetScale = Math.max(scaleX, scaleY);
+          const bgSprite = new PIXI.Sprite(texture);
+          bgSprite.scale.x = targetScale;
+          bgSprite.scale.y = targetScale;
+          bgSprite.anchor.set(0.5);
+          bgSprite.position.y = this.stageHeight / 2;
+          thisBgContainer.setBaseX(this.stageWidth / 2);
+          thisBgContainer.setBaseY(this.stageHeight / 2);
+          thisBgContainer.pivot.set(0, this.stageHeight / 2);
+          thisBgContainer.addChild(bgSprite);
+        });
+      }
+      onLoaded();
     };
 
     /**
@@ -517,7 +511,7 @@ export default class PixiStage {
    * @param url 立绘图片url
    * @param presetPosition
    */
-  public addFigure(key: string, url: string, presetPosition: 'left' | 'center' | 'right' = 'center') {
+  public addFigure(onLoaded: () => void, key: string, url: string, presetPosition: 'left' | 'center' | 'right' = 'center') {
     const loader = this.assetLoader;
     // 准备用于存放这个立绘的 Container
     const thisFigureContainer = new WebGALPixiContainer();
@@ -551,42 +545,40 @@ export default class PixiStage {
 
     // 完成图片加载后执行的函数
     const setup = () => {
-      // TODO：找一个更好的解法，现在的解法是无论是否复用原来的资源，都设置一个延时以让动画工作正常！
-      setTimeout(() => {
-        const texture = loader.resources?.[url]?.texture;
-        if (texture && this.getStageObjByUuid(figureUuid)) {
-          /**
-           * 重设大小
-           */
-          const originalWidth = texture.width;
-          const originalHeight = texture.height;
-          const scaleX = this.stageWidth / originalWidth;
-          const scaleY = this.stageHeight / originalHeight;
-          const targetScale = Math.min(scaleX, scaleY);
-          const figureSprite = new PIXI.Sprite(texture);
-          figureSprite.scale.x = targetScale;
-          figureSprite.scale.y = targetScale;
-          figureSprite.anchor.set(0.5);
-          figureSprite.position.y = this.stageHeight / 2;
-          const targetWidth = originalWidth * targetScale;
-          const targetHeight = originalHeight * targetScale;
-          thisFigureContainer.setBaseY(this.stageHeight / 2);
-          if (targetHeight < this.stageHeight) {
-            thisFigureContainer.setBaseY(this.stageHeight / 2 + (this.stageHeight - targetHeight) / 2);
-          }
-          if (presetPosition === 'center') {
-            thisFigureContainer.setBaseX(this.stageWidth / 2);
-          }
-          if (presetPosition === 'left') {
-            thisFigureContainer.setBaseX(targetWidth / 2);
-          }
-          if (presetPosition === 'right') {
-            thisFigureContainer.setBaseX(this.stageWidth - targetWidth / 2);
-          }
-          thisFigureContainer.pivot.set(0, this.stageHeight / 2);
-          thisFigureContainer.addChild(figureSprite);
+      const texture = loader.resources?.[url]?.texture;
+      if (texture && this.getStageObjByUuid(figureUuid)) {
+        /**
+         * 重设大小
+         */
+        const originalWidth = texture.width;
+        const originalHeight = texture.height;
+        const scaleX = this.stageWidth / originalWidth;
+        const scaleY = this.stageHeight / originalHeight;
+        const targetScale = Math.min(scaleX, scaleY);
+        const figureSprite = new PIXI.Sprite(texture);
+        figureSprite.scale.x = targetScale;
+        figureSprite.scale.y = targetScale;
+        figureSprite.anchor.set(0.5);
+        figureSprite.position.y = this.stageHeight / 2;
+        const targetWidth = originalWidth * targetScale;
+        const targetHeight = originalHeight * targetScale;
+        thisFigureContainer.setBaseY(this.stageHeight / 2);
+        if (targetHeight < this.stageHeight) {
+          thisFigureContainer.setBaseY(this.stageHeight / 2 + (this.stageHeight - targetHeight) / 2);
         }
-      }, 0);
+        if (presetPosition === 'center') {
+          thisFigureContainer.setBaseX(this.stageWidth / 2);
+        }
+        if (presetPosition === 'left') {
+          thisFigureContainer.setBaseX(targetWidth / 2);
+        }
+        if (presetPosition === 'right') {
+          thisFigureContainer.setBaseX(this.stageWidth - targetWidth / 2);
+        }
+        thisFigureContainer.pivot.set(0, this.stageHeight / 2);
+        thisFigureContainer.addChild(figureSprite);
+      }
+      onLoaded();
     };
 
     /**
@@ -606,7 +598,7 @@ export default class PixiStage {
    * @param jsonPath
    */
   // eslint-disable-next-line max-params
-  public addLive2dFigure(key: string, jsonPath: string, pos: string, motion: string, expression: string) {
+  public addLive2dFigure(onLoaded: () => void, key: string, jsonPath: string, pos: string, motion: string, expression: string) {
     if (this.isLive2dAvailable !== true) return;
     try {
       let stageWidth = this.stageWidth;
@@ -733,6 +725,7 @@ export default class PixiStage {
             });
           })();
         }
+        onLoaded();
       };
 
       /**

--- a/packages/webgal/src/Core/controller/stage/pixi/spine.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/spine.ts
@@ -53,6 +53,7 @@ export async function loadPixiSpine(): Promise<typeof import('pixi-spine') | nul
 // eslint-disable-next-line max-params
 export async function addSpineFigureImpl(
   this: PixiStage,
+  onLoaded: () => void,
   key: string,
   url: string,
   presetPosition: 'left' | 'center' | 'right' = 'center',
@@ -140,6 +141,7 @@ export async function addSpineFigureImpl(
       thisFigureContainer.pivot.set(0, this.stageHeight / 2);
       thisFigureContainer.addChild(figureSprite);
     }
+    onLoaded();
   };
 
   /**
@@ -161,7 +163,7 @@ export async function addSpineFigureImpl(
  * @param key 背景的标识
  * @param url Spine 数据的 URL
  */
-export async function addSpineBgImpl(this: PixiStage, key: string, url: string) {
+export async function addSpineBgImpl(this: PixiStage, onLoaded: () => void, key: string, url: string) {
   const spineId = `spine-${url}`;
   // 准备用于存放这个背景的 Container
   const thisBgContainer = new WebGALPixiContainer();
@@ -199,39 +201,37 @@ export async function addSpineBgImpl(this: PixiStage, key: string, url: string) 
 
     const { Spine } = pixiSpine;
     const spineResource: any = spineLoader!.resources?.[spineId];
-    // TODO：找一个更好的解法，现在的解法是无论是否复用原来的资源，都设置一个延时以让动画工作正常！
-    setTimeout(() => {
-      if (spineResource && this.getStageObjByUuid(bgUuid)) {
-        const bgSpine = new Spine(spineResource.spineData);
-        const transY = spineResource?.spineData?.y ?? 0;
-        /**
-         * 重设大小
-         */
-        const originalWidth = bgSpine.width; // TODO: 视图大小可能小于画布大小，应提供参数指定视图大小
-        const originalHeight = bgSpine.height; // TODO: 视图大小可能小于画布大小，应提供参数指定视图大小
-        const scaleX = this.stageWidth / originalWidth;
-        const scaleY = this.stageHeight / originalHeight;
-        logger.debug('bgSpine state', bgSpine.state);
-        // TODO: 也许应该使用 setAnimation 播放初始动画
-        if (bgSpine.spineData.animations.length > 0) {
-          // 播放首个动画
-          bgSpine.state.setAnimation(0, bgSpine.spineData.animations[0].name, true);
-        }
-        const targetScale = Math.max(scaleX, scaleY);
-        const bgSprite = new PIXI.Sprite();
-        bgSprite.addChild(bgSpine);
-        bgSprite.scale.x = targetScale;
-        bgSprite.scale.y = targetScale;
-        bgSprite.anchor.set(0.5);
-        bgSprite.position.y = this.stageHeight / 2;
-        thisBgContainer.setBaseX(this.stageWidth / 2);
-        thisBgContainer.setBaseY(this.stageHeight / 2);
-        thisBgContainer.pivot.set(0, this.stageHeight / 2);
-
-        // 挂载
-        thisBgContainer.addChild(bgSprite);
+    if (spineResource && this.getStageObjByUuid(bgUuid)) {
+      const bgSpine = new Spine(spineResource.spineData);
+      const transY = spineResource?.spineData?.y ?? 0;
+      /**
+       * 重设大小
+       */
+      const originalWidth = bgSpine.width; // TODO: 视图大小可能小于画布大小，应提供参数指定视图大小
+      const originalHeight = bgSpine.height; // TODO: 视图大小可能小于画布大小，应提供参数指定视图大小
+      const scaleX = this.stageWidth / originalWidth;
+      const scaleY = this.stageHeight / originalHeight;
+      logger.debug('bgSpine state', bgSpine.state);
+      // TODO: 也许应该使用 setAnimation 播放初始动画
+      if (bgSpine.spineData.animations.length > 0) {
+        // 播放首个动画
+        bgSpine.state.setAnimation(0, bgSpine.spineData.animations[0].name, true);
       }
-    }, 0);
+      const targetScale = Math.max(scaleX, scaleY);
+      const bgSprite = new PIXI.Sprite();
+      bgSprite.addChild(bgSpine);
+      bgSprite.scale.x = targetScale;
+      bgSprite.scale.y = targetScale;
+      bgSprite.anchor.set(0.5);
+      bgSprite.position.y = this.stageHeight / 2;
+      thisBgContainer.setBaseX(this.stageWidth / 2);
+      thisBgContainer.setBaseY(this.stageHeight / 2);
+      thisBgContainer.pivot.set(0, this.stageHeight / 2);
+
+      // 挂载
+      thisBgContainer.addChild(bgSprite);
+    }
+    onLoaded();
   };
 
   /**

--- a/packages/webgal/src/Core/controller/stage/pixi/spine.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/spine.ts
@@ -2,7 +2,7 @@
 import { WebGALPixiContainer } from '@/Core/controller/stage/pixi/WebGALPixiContainer';
 import { v4 as uuid } from 'uuid';
 import * as PIXI from 'pixi.js';
-import PixiStage from '@/Core/controller/stage/pixi/PixiController';
+import PixiStage, { IStageObject } from '@/Core/controller/stage/pixi/PixiController';
 import { logger } from '@/Core/util/logger';
 // utils/loadPixiSpine.ts
 // @ts-ignore
@@ -81,14 +81,16 @@ export async function addSpineFigureImpl(
   // 挂载
   this.figureContainer.addChild(thisFigureContainer);
   const figureUuid = uuid();
-  this.figureObjects.push({
+  const stageObject: IStageObject = {
     uuid: figureUuid,
     key: key,
     pixiContainer: thisFigureContainer,
+    ignoreOnLoaded: false,
     sourceUrl: url,
     sourceType: 'spine', // 修改为 'spine'
     sourceExt: this.getExtName(url),
-  });
+  };
+  this.figureObjects.push(stageObject);
 
   // 完成图片加载后执行的函数
   const setup = async () => {
@@ -141,7 +143,9 @@ export async function addSpineFigureImpl(
       thisFigureContainer.pivot.set(0, this.stageHeight / 2);
       thisFigureContainer.addChild(figureSprite);
     }
-    onLoaded();
+    if (!stageObject.ignoreOnLoaded) {
+      onLoaded();
+    }
   };
 
   /**
@@ -181,14 +185,16 @@ export async function addSpineBgImpl(this: PixiStage, onLoaded: () => void, key:
   // 挂载
   this.backgroundContainer.addChild(thisBgContainer);
   const bgUuid = uuid();
-  this.backgroundObjects.push({
+  const stageObject: IStageObject = {
     uuid: bgUuid,
     key: key,
     pixiContainer: thisBgContainer,
+    ignoreOnLoaded: false,
     sourceUrl: url,
     sourceType: 'spine', // 修改为 'spine'
     sourceExt: this.getExtName(url),
-  });
+  };
+  this.backgroundObjects.push(stageObject);
 
   // 完成图片加载后执行的函数
   const setup = async () => {
@@ -231,7 +237,9 @@ export async function addSpineBgImpl(this: PixiStage, onLoaded: () => void, key:
       // 挂载
       thisBgContainer.addChild(bgSprite);
     }
-    onLoaded();
+    if (!stageObject.ignoreOnLoaded) {
+      onLoaded();
+    }
   };
 
   /**

--- a/packages/webgal/src/Stage/MainStage/useSetBg.ts
+++ b/packages/webgal/src/Stage/MainStage/useSetBg.ts
@@ -22,12 +22,14 @@ export function useSetBg(stageState: IStageState) {
           removeBg(currentBg);
         }
       }
-      addBg(undefined, thisBgKey, bgName);
-      setEbg(bgName);
-      logger.debug('重设背景');
-      const { duration, animation } = getEnterExitAnimation('bg-main', 'enter', true);
-      WebGAL.gameplay.pixiStage!.registerPresetAnimation(animation, 'bg-main-softin', thisBgKey, stageState.effects);
-      setTimeout(() => WebGAL.gameplay.pixiStage!.removeAnimationWithSetEffects('bg-main-softin'), duration);
+      const onLoaded = () => {
+        setEbg(bgName);
+        logger.debug('重设背景');
+        const { duration, animation } = getEnterExitAnimation('bg-main', 'enter', true);
+        WebGAL.gameplay.pixiStage!.registerPresetAnimation(animation, 'bg-main-softin', thisBgKey, stageState.effects);
+        setTimeout(() => WebGAL.gameplay.pixiStage!.removeAnimationWithSetEffects('bg-main-softin'), duration);
+      };
+      addBg(onLoaded, undefined, thisBgKey, bgName);
     } else {
       const currentBg = WebGAL.gameplay.pixiStage?.getStageObjByKey(thisBgKey);
       if (currentBg) {
@@ -52,16 +54,16 @@ function removeBg(bgObject: IStageObject) {
   }, duration);
 }
 
-function addBg(type?: 'image' | 'spine', ...args: any[]) {
+function addBg(onLoaded: () => void, type?: 'image' | 'spine', ...args: any[]) {
   const url = args[1];
   if (url.endsWith('.mp4')) {
     // @ts-ignore
-    return WebGAL.gameplay.pixiStage?.addVideoBg(...args);
+    return WebGAL.gameplay.pixiStage?.addVideoBg(onLoaded, ...args);
   } else if (url.endsWith('.skel')) {
     // @ts-ignore
-    return WebGAL.gameplay.pixiStage?.addSpineBg(...args);
+    return WebGAL.gameplay.pixiStage?.addSpineBg(onLoaded, ...args);
   } else {
     // @ts-ignore
-    return WebGAL.gameplay.pixiStage?.addBg(...args);
+    return WebGAL.gameplay.pixiStage?.addBg(onLoaded, ...args);
   }
 }

--- a/packages/webgal/src/Stage/MainStage/useSetFigure.ts
+++ b/packages/webgal/src/Stage/MainStage/useSetFigure.ts
@@ -45,11 +45,13 @@ export function useSetFigure(stageState: IStageState) {
           removeFig(currentFigCenter, softInAniKey, stageState.effects);
         }
       }
-      addFigure(undefined, thisFigKey, figName, 'center');
-      logger.debug('中立绘已重设');
-      const { duration, animation } = getEnterExitAnimation(thisFigKey, 'enter');
-      WebGAL.gameplay.pixiStage!.registerPresetAnimation(animation, softInAniKey, thisFigKey, stageState.effects);
-      setTimeout(() => WebGAL.gameplay.pixiStage!.removeAnimationWithSetEffects(softInAniKey), duration);
+      const onLoaded = () => {
+        logger.debug('中立绘已重设');
+        const { duration, animation } = getEnterExitAnimation(thisFigKey, 'enter');
+        WebGAL.gameplay.pixiStage!.registerPresetAnimation(animation, softInAniKey, thisFigKey, stageState.effects);
+        setTimeout(() => WebGAL.gameplay.pixiStage!.removeAnimationWithSetEffects(softInAniKey), duration);
+      };
+      addFigure(onLoaded, undefined, thisFigKey, figName, 'center');
     } else {
       logger.debug('移除中立绘');
       const currentFigCenter = WebGAL.gameplay.pixiStage?.getStageObjByKey(thisFigKey);
@@ -74,11 +76,13 @@ export function useSetFigure(stageState: IStageState) {
           removeFig(currentFigLeft, softInAniKey, stageState.effects);
         }
       }
-      addFigure(undefined, thisFigKey, figNameLeft, 'left');
-      logger.debug('左立绘已重设');
-      const { duration, animation } = getEnterExitAnimation(thisFigKey, 'enter');
-      WebGAL.gameplay.pixiStage!.registerPresetAnimation(animation, softInAniKey, thisFigKey, stageState.effects);
-      setTimeout(() => WebGAL.gameplay.pixiStage!.removeAnimationWithSetEffects(softInAniKey), duration);
+      const onLoaded = () => {
+        logger.debug('左立绘已重设');
+        const { duration, animation } = getEnterExitAnimation(thisFigKey, 'enter');
+        WebGAL.gameplay.pixiStage!.registerPresetAnimation(animation, softInAniKey, thisFigKey, stageState.effects);
+        setTimeout(() => WebGAL.gameplay.pixiStage!.removeAnimationWithSetEffects(softInAniKey), duration);
+      };
+      addFigure(onLoaded, undefined, thisFigKey, figNameLeft, 'left');
     } else {
       logger.debug('移除左立绘');
       const currentFigLeft = WebGAL.gameplay.pixiStage?.getStageObjByKey(thisFigKey);
@@ -103,11 +107,13 @@ export function useSetFigure(stageState: IStageState) {
           removeFig(currentFigRight, softInAniKey, stageState.effects);
         }
       }
-      addFigure(undefined, thisFigKey, figNameRight, 'right');
-      logger.debug('右立绘已重设');
-      const { duration, animation } = getEnterExitAnimation(thisFigKey, 'enter');
-      WebGAL.gameplay.pixiStage!.registerPresetAnimation(animation, softInAniKey, thisFigKey, stageState.effects);
-      setTimeout(() => WebGAL.gameplay.pixiStage!.removeAnimationWithSetEffects(softInAniKey), duration);
+      const onLoaded = () => {
+        logger.debug('右立绘已重设');
+        const { duration, animation } = getEnterExitAnimation(thisFigKey, 'enter');
+        WebGAL.gameplay.pixiStage!.registerPresetAnimation(animation, softInAniKey, thisFigKey, stageState.effects);
+        setTimeout(() => WebGAL.gameplay.pixiStage!.removeAnimationWithSetEffects(softInAniKey), duration);
+      };
+      addFigure(onLoaded, undefined, thisFigKey, figNameRight, 'right');
     } else {
       const currentFigRight = WebGAL.gameplay.pixiStage?.getStageObjByKey(thisFigKey);
       if (currentFigRight) {
@@ -134,18 +140,22 @@ export function useSetFigure(stageState: IStageState) {
         if (currentFigThisKey) {
           if (currentFigThisKey.sourceUrl !== fig.name) {
             removeFig(currentFigThisKey, softInAniKey, stageState.effects);
-            addFigure(undefined, thisFigKey, fig.name, fig.basePosition);
+            const onLoaded = () => {
+              logger.debug(`${fig.key}立绘已重设`);
+              const { duration, animation } = getEnterExitAnimation(thisFigKey, 'enter');
+              WebGAL.gameplay.pixiStage!.registerPresetAnimation(animation, softInAniKey, thisFigKey, stageState.effects);
+              setTimeout(() => WebGAL.gameplay.pixiStage!.removeAnimationWithSetEffects(softInAniKey), duration);
+            };
+            addFigure(onLoaded, undefined, thisFigKey, fig.name, fig.basePosition);
+          }
+        } else {
+          const onLoaded = () => {
             logger.debug(`${fig.key}立绘已重设`);
             const { duration, animation } = getEnterExitAnimation(thisFigKey, 'enter');
             WebGAL.gameplay.pixiStage!.registerPresetAnimation(animation, softInAniKey, thisFigKey, stageState.effects);
             setTimeout(() => WebGAL.gameplay.pixiStage!.removeAnimationWithSetEffects(softInAniKey), duration);
-          }
-        } else {
-          addFigure(undefined, thisFigKey, fig.name, fig.basePosition);
-          logger.debug(`${fig.key}立绘已重设`);
-          const { duration, animation } = getEnterExitAnimation(thisFigKey, 'enter');
-          WebGAL.gameplay.pixiStage!.registerPresetAnimation(animation, softInAniKey, thisFigKey, stageState.effects);
-          setTimeout(() => WebGAL.gameplay.pixiStage!.removeAnimationWithSetEffects(softInAniKey), duration);
+          };
+          addFigure(onLoaded, undefined, thisFigKey, fig.name, fig.basePosition);
         }
       } else {
         const currentFigThisKey = WebGAL.gameplay.pixiStage?.getStageObjByKey(thisFigKey);
@@ -205,19 +215,19 @@ function removeFig(figObj: IStageObject, enterTikerKey: string, effects: IEffect
   }, duration);
 }
 
-function addFigure(type?: 'image' | 'live2D' | 'spine', ...args: any[]) {
+async function addFigure(onLoaded: () => void, type?: 'image' | 'live2D' | 'spine', ...args: any[]) {
   const url = args[1];
   const baseUrl = window.location.origin;
   const urlObject = new URL(url, baseUrl);
   const _type = urlObject.searchParams.get('type') as 'image' | 'live2D' | 'spine' | null;
   if (url.endsWith('.json')) {
-    return addLive2dFigure(...args);
+    return await addLive2dFigure(onLoaded, ...args);
   } else if (url.endsWith('.skel') || _type === 'spine') {
     // @ts-ignore
-    return WebGAL.gameplay.pixiStage?.addSpineFigure(...args);
+    return WebGAL.gameplay.pixiStage?.addSpineFigure(onLoaded, ...args);
   } else {
     // @ts-ignore
-    return WebGAL.gameplay.pixiStage?.addFigure(...args);
+    return WebGAL.gameplay.pixiStage?.addFigure(onLoaded, ...args);
   }
 }
 
@@ -225,7 +235,7 @@ function addFigure(type?: 'image' | 'live2D' | 'spine', ...args: any[]) {
  * 如果要使用 Live2D，取消这里的注释
  * @param args
  */
-function addLive2dFigure(...args: any[]) {
+function addLive2dFigure(onLoaded: () => void, ...args: any[]) {
   // @ts-ignore
-  return WebGAL.gameplay.pixiStage?.addLive2dFigure(...args);
+  return WebGAL.gameplay.pixiStage?.addLive2dFigure(onLoaded, ...args);
 }


### PR DESCRIPTION
# 介绍
修复 当资源未及时加载时, 入场动画不能正常播放 的问题

# 主要更改
- 为 `addFigure` `addLive2dFigure` `addSpineFigure` `addBg` `addVideoBg` `addSpineBg` 新增 `onLoaded: () => void` 参数
- 移除不必要的 `setTimeout`

# 测试
请自行在支持 Live2d 的引擎上, 在场景里加载多个 live2d 模型, 最好 next 成一起, 第一次出场时能看到所有 figure 能正常播放入场动画