### PR TITLE
fix: update video background extname

### DIFF
--- a/packages/webgal/src/Stage/MainStage/useSetBg.ts
+++ b/packages/webgal/src/Stage/MainStage/useSetBg.ts
@@ -53,11 +53,11 @@ function removeBg(bgObject: IStageObject) {
 }
 
 function addBg(type?: 'image' | 'spine', ...args: any[]) {
-  const url = args[1];
-  if (url.endsWith('.mp4')) {
+  const url: string = args[1];
+  if (['mp4', 'webm', 'mkv'].some((e) => url.toLocaleLowerCase().endsWith(e))) {
     // @ts-ignore
     return WebGAL.gameplay.pixiStage?.addVideoBg(...args);
-  } else if (url.endsWith('.skel')) {
+  } else if (url.toLocaleLowerCase().endsWith('.skel')) {
     // @ts-ignore
     return WebGAL.gameplay.pixiStage?.addSpineBg(...args);
   } else {

--- a/packages/webgal/src/UI/Extra/ExtraCgElement.tsx
+++ b/packages/webgal/src/UI/Extra/ExtraCgElement.tsx
@@ -17,7 +17,7 @@ export function ExtraCgElement(props: IProps) {
   // Determine if the resource is a video based on file extension
   const isVideo = useMemo(() => {
     const extension = props.resourceUrl.split('.').pop()?.toLowerCase() || '';
-    return ['mp4', 'webm', 'mov', 'avi', 'mkv'].includes(extension);
+    return ['mp4', 'webm', 'mkv'].includes(extension);
   }, [props.resourceUrl]);
 
   // Determine if the resource is an image based on file extension


### PR DESCRIPTION
经测试，目前不支持播放 `mov` 和 `avi` 的视频，可以播放 `mp4`、`webm` 和 `mkv`，其他视频格式需验证