### PR TITLE
feat: improve bevel filter

### DIFF
--- a/packages/webgal/src/Core/controller/stage/pixi/WebGALPixiContainer.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/WebGALPixiContainer.ts
@@ -4,7 +4,8 @@ import { ReflectionFilter } from '@pixi/filter-reflection';
 import { GlitchFilter } from '@pixi/filter-glitch';
 import { RGBSplitFilter } from '@pixi/filter-rgb-split';
 import { GodrayFilter } from '@pixi/filter-godray';
-import { AdjustmentFilter, AdvancedBloomFilter, BevelFilter, ShockwaveFilter } from 'pixi-filters';
+import { AdjustmentFilter, AdvancedBloomFilter, ShockwaveFilter } from 'pixi-filters';
+import { BevelFilter } from '@/Core/controller/stage/pixi/shaders/BevelFilter'
 import * as PIXI from 'pixi.js';
 import { BlurFilter } from '@pixi/filter-blur';
 import { INIT_RAD, RadiusAlphaFilter } from '@/Core/controller/stage/pixi/shaders/RadiusAlphaFilter';
@@ -127,6 +128,7 @@ const FILTER_CONFIGS: Record<string, FilterConfig> = {
       f.lightAlpha = 0; // bevel
       f.thickness = 0; // bevelThickness
       f.rotation = 0; // bevelRotation
+      f.softness = 0; // bevelSoftness
       // 默认 lightColor (255, 255, 255) -> 0xFFFFFF
       f.lightColor = 0xffffff;
       f.shadowAlpha = 0; // 通常边缘光不需要阴影
@@ -138,6 +140,7 @@ const FILTER_CONFIGS: Record<string, FilterConfig> = {
         b.lightAlpha === 0 &&
         b.thickness === 0 &&
         b.rotation === 0 &&
+        b.softness === 0 &&
         b.lightColor === 0xffffff && // 假设默认白色
         b.shadowAlpha === 0
       );
@@ -245,6 +248,11 @@ const PROPERTY_CONFIGS: Record<string, PropertyConfig> = {
   bevelRotation: {
     filterName: 'bevel',
     filterProperty: 'rotation',
+    defaultValue: 0,
+  },
+  bevelSoftness: {
+    filterName: 'bevel',
+    filterProperty: 'softness',
     defaultValue: 0,
   },
   bevelRed: {
@@ -496,6 +504,13 @@ export class WebGALPixiContainer extends PIXI.Container {
   }
   public set bevelRotation(v: number) {
     this._setPropertyValue('bevelRotation', v);
+  }
+
+  public get bevelSoftness(): number {
+    return this._getPropertyValue('bevelSoftness');
+  }
+  public set bevelSoftness(v: number) {
+    this._setPropertyValue('bevelSoftness', v);
   }
 
   public get bevelRed(): number {

--- a/packages/webgal/src/Core/controller/stage/pixi/shaders/BevelFilter.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/shaders/BevelFilter.ts
@@ -1,0 +1,227 @@
+import { Filter, FilterState, FilterSystem, RenderTexture } from '@pixi/core';
+import { DEG_TO_RAD } from '@pixi/math';
+import { rgb2hex, hex2rgb } from '@pixi/utils';
+import { MotionBlurFilter } from 'pixi-filters';
+import { CLEAR_MODES } from 'pixi.js';
+
+interface BevelFilterOptions {
+    rotation: number,
+    thickness: number,
+    lightColor: number,
+    lightAlpha: number,
+    shadowColor: number,
+    shadowAlpha: number,
+}
+
+/**
+ * Bevel Filter.<br>
+ *
+ * @class
+ * @extends PIXI.Filter
+ * @memberof PIXI.filters
+ * @see {@link https://www.npmjs.com/package/@pixi/filter-bevel|@pixi/filter-bevel}
+ * @see {@link https://www.npmjs.com/package/pixi-filters|pixi-filters}
+ */
+class BevelFilter extends Filter
+{
+    private _thickness = 2;
+    private _angle = 0;
+    private _softness = 0;
+
+    private _blurFilter = new MotionBlurFilter()
+
+    /**
+     * @param {object} [options] - The optional parameters of the filter.
+     * @param {number} [options.rotation = 45] - The angle of the light in degrees.
+     * @param {number} [options.thickness = 2] - The tickness of the bevel.
+     * @param {number} [options.lightColor = 0xffffff] - Color of the light.
+     * @param {number} [options.lightAlpha = 0.7] - Alpha of the light.
+     * @param {number} [options.shadowColor = 0x000000] - Color of the shadow.
+     * @param {number} [options.shadowAlpha = 0.7] - Alpha of the shadow.
+     */
+    constructor(options?: Partial<BevelFilterOptions>)
+    {
+        const fragment = `precision mediump float;
+
+varying vec2 vTextureCoord;
+uniform sampler2D uSampler;
+uniform sampler2D mask;
+uniform vec4 filterArea;
+
+uniform float transformX;
+uniform float transformY;
+uniform vec3 lightColor;
+uniform float lightAlpha;
+uniform vec3 shadowColor;
+uniform float shadowAlpha;
+
+void main(void) {
+    vec2 transform = vec2(1.0 / filterArea) * vec2(transformX, transformY);
+    vec4 color = texture2D(uSampler, vTextureCoord);
+    float light = texture2D(mask, vTextureCoord - transform).a;
+    float shadow = texture2D(mask, vTextureCoord + transform).a;
+
+    // color.rgb = mix(color.rgb, lightColor, clamp((color.a - light) * lightAlpha, 0.0, 1.0));
+    // color.rgb = mix(color.rgb, shadowColor, clamp((color.a - shadow) * shadowAlpha, 0.0, 1.0));
+    
+    // 滤色
+    color.rgb = mix(color.rgb, vec3(1.0) - (vec3(1.0) - color.rgb) * (vec3(1.0) - lightColor), clamp((color.a - light) * lightAlpha, 0.0, 1.0));
+    // 正片叠底(相乘)
+    color.rgb = mix(color.rgb, color.rgb * shadowColor, clamp((color.a - shadow) * shadowAlpha, 0.0, 1.0));
+
+    gl_FragColor = vec4(color.rgb, color.a);
+}`;
+        super(null as any, fragment);
+
+        this.uniforms.lightColor = new Float32Array(3);
+        this.uniforms.shadowColor = new Float32Array(3);
+
+        Object.assign(this, {
+            rotation: 45,
+            thickness: 2,
+            lightColor: 0xffffff,
+            lightAlpha: 0.7,
+            shadowColor: 0x000000,
+            shadowAlpha: 0.7,
+        }, options);
+
+        // Workaround: https://github.com/pixijs/filters/issues/230
+        // applies correctly only if there is at least a single-pixel padding with alpha=0 around an image
+        // To solve this problem, a padding of 1 put on the filter should suffice
+        this.padding = 1;
+
+        this._blurFilter.kernelSize = 11;
+    }
+
+    apply(filterManager: FilterSystem, input: RenderTexture, output: RenderTexture, clearMode?: CLEAR_MODES, _currentState?: FilterState): void {
+        if (this.softness > 0) {
+            const blurTexture = filterManager.getFilterTexture();
+            this._blurFilter.apply(filterManager, input, blurTexture, CLEAR_MODES.YES);
+
+            this.uniforms.mask = blurTexture;
+            filterManager.applyFilter(this, input, output, clearMode);
+
+            filterManager.returnFilterTexture(blurTexture);
+        } else {
+            this.uniforms.mask = input;
+            filterManager.applyFilter(this, input, output, clearMode);
+        }
+    }
+
+    /**
+     * Update the transform matrix of offset angle.
+     * @private
+     */
+    private _updateTransform()
+    {
+        this.uniforms.transformX = this._thickness * Math.cos(this._angle);
+        this.uniforms.transformY = this._thickness * Math.sin(this._angle);
+    }
+    
+    private _updateBlur()
+    {
+        this._blurFilter.velocity.set(
+            Math.cos(this._angle) * this.thickness * this.softness * -1,
+            Math.sin(this._angle) * this.thickness * this.softness * -1
+        );
+    }
+
+    /**
+     * The angle of the light in degrees.
+     * @default 45
+     */
+    get rotation(): number
+    {
+        return this._angle / DEG_TO_RAD;
+    }
+    set rotation(value: number)
+    {
+        this._angle = value * DEG_TO_RAD;
+        this._updateTransform();
+        this._updateBlur();
+    }
+
+    /**
+     * The tickness of the bevel.
+     * @default 2
+     */
+    get thickness(): number
+    {
+        return this._thickness;
+    }
+    set thickness(value: number)
+    {
+        this._thickness = value;
+        this._updateTransform();
+        this._updateBlur();
+    }
+
+    /**
+     * The tickness of the bevel. Range [0, 1]
+     * @default 0
+     */
+    get softness(): number
+    {
+        return this._softness;
+    }
+    set softness(value: number)
+    {
+        this._softness = Math.min(Math.max(value, 0), 1);
+        this._updateBlur();
+    }
+
+    /**
+     * Color of the light.
+     * @default 0xffffff
+     */
+    get lightColor(): number
+    {
+        return rgb2hex(this.uniforms.lightColor);
+    }
+    set lightColor(value: number)
+    {
+        hex2rgb(value, this.uniforms.lightColor);
+    }
+
+    /**
+     * Alpha of the light.
+     * @default 0.7
+     */
+    get lightAlpha(): number
+    {
+        return this.uniforms.lightAlpha;
+    }
+    set lightAlpha(value: number)
+    {
+        this.uniforms.lightAlpha = value;
+    }
+
+    /**
+     * Color of the shadow.
+     * @default 0x000000
+     */
+    get shadowColor(): number
+    {
+        return rgb2hex(this.uniforms.shadowColor);
+    }
+    set shadowColor(value: number)
+    {
+        hex2rgb(value, this.uniforms.shadowColor);
+    }
+
+    /**
+     * Alpha of the shadow.
+     * @default 0.7
+     */
+    get shadowAlpha(): number
+    {
+        return this.uniforms.shadowAlpha;
+    }
+    set shadowAlpha(value: number)
+    {
+        this.uniforms.shadowAlpha = value;
+    }
+}
+
+export { BevelFilter };
+export type { BevelFilterOptions };

--- a/packages/webgal/src/store/stageInterface.ts
+++ b/packages/webgal/src/store/stageInterface.ts
@@ -49,6 +49,7 @@ export interface ITransform {
   bevel: number;
   bevelThickness: number;
   bevelRotation: number;
+  bevelSoftness: number;
   bevelRed: number;
   bevelGreen: number;
   bevelBlue: number;
@@ -98,6 +99,7 @@ export const baseTransform: ITransform = {
   bevel: 0,
   bevelThickness: 0,
   bevelRotation: 0,
+  bevelSoftness: 0,
   bevelRed: 255,
   bevelGreen: 255,
   bevelBlue: 255,


### PR DESCRIPTION
# 介绍
改进了倒角滤镜

<table>
<tr>
<td align="center">Before</td>
<td align="center">After</td>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/542d7b08-6ee5-4458-aa2d-75fc033bfd64">
</td>
<td>
<img src="https://github.com/user-attachments/assets/79189afc-be3e-41f0-a25e-cb3882672220">
</td>
</tr>
</table>

# 主要更改
- 新增自定义 BevelFilter
- 倒角的亮部混合模式更改为 __滤色__ , 暗部更改为 __正片叠底__
- 修复半透明立绘应用倒角时, 颜色被压暗的问题
- 新增 `bevelSoftness` 属性, 范围 0~1, 控制倒角软化程度

# 测试
```js
changeBg:bg.png -next;
changeFigure:stand.png -id=aaa;
setTransform:{"brightness":0.1,"contrast":1.5,"saturation":0.8,"gamma":0.8,"bloom":1,"bloomBrightness":1,"bloomBlur":10} -target=bg-main -duration=2000 -next;
setTransform:{"brightness":0.5,"bloom":1,"bloomBlur":10,"bloomThreshold":0.6,"bevel":0.8,"bevelSoftness":1,"bevelRed":85,"bevelGreen":205,"bevelThickness":20,"bevelRotation":60} -target=aaa -duration=2000;
```