### PR TITLE
feat: allow backgroundImage for Intro, fail to fetch image will fallback to backgroundColor

### DIFF
--- a/packages/webgal/src/Core/gameScripts/intro.tsx
+++ b/packages/webgal/src/Core/gameScripts/intro.tsx
@@ -48,7 +48,7 @@ export const intro = (sentence: ISentence): IPerform => {
   let isUserForward = false;
   for (const e of sentence.args) {
     if(e.key === 'backgroundImage'){
-      backgroundImage = `url("game/template/Intro/${e.value}") center/cover no-repeat`;
+      backgroundImage = `url("game/background/${e.value}") center/cover no-repeat`;
     }
     if (e.key === 'backgroundColor') {
       backgroundColor = e.value || 'rgba(0, 0, 0, 1)';

--- a/packages/webgal/src/Core/gameScripts/intro.tsx
+++ b/packages/webgal/src/Core/gameScripts/intro.tsx
@@ -20,6 +20,10 @@ export const intro = (sentence: ISentence): IPerform => {
 
   const performName = `introPerform${Math.random().toString()}`;
   let fontSize: string | undefined;
+  // 'url("/game/template/Intro/bg.webp") center/cover no-repeat, url("/game/template/Intro/bga.webp") center/cover no-repeat'
+  let backgroundImage: any = ['webp', 'png', 'jpg'].reduce((pre, cur, curInd) => {
+    return pre + `${curInd === 0 ? '' : ', '}url("/game/template/Intro/bg.${cur}") center/cover no-repeat`;
+  }, '');
   let backgroundColor: any = 'rgba(0, 0, 0, 1)';
   let color: any = 'rgba(255, 255, 255, 1)';
   const animationClass: any = (type: string, length = 0) => {
@@ -42,8 +46,10 @@ export const intro = (sentence: ISentence): IPerform => {
   let delayTime = 1500;
   let isHold = false;
   let isUserForward = false;
-
   for (const e of sentence.args) {
+    if(e.key === 'backgroundImage'){
+      backgroundImage = `url("/game/template/Intro/${e.value}") center/cover no-repeat`;
+    }
     if (e.key === 'backgroundColor') {
       backgroundColor = e.value || 'rgba(0, 0, 0, 1)';
     }
@@ -86,7 +92,8 @@ export const intro = (sentence: ISentence): IPerform => {
   }
 
   const introContainerStyle = {
-    background: backgroundColor,
+    background: backgroundImage,
+    backgroundColor: backgroundColor,
     color: color,
     fontSize: fontSize || '350%',
     width: '100%',

--- a/packages/webgal/src/Core/gameScripts/intro.tsx
+++ b/packages/webgal/src/Core/gameScripts/intro.tsx
@@ -22,7 +22,7 @@ export const intro = (sentence: ISentence): IPerform => {
   let fontSize: string | undefined;
   // 'url("/game/template/Intro/bg.webp") center/cover no-repeat, url("/game/template/Intro/bga.webp") center/cover no-repeat'
   let backgroundImage: any = ['webp', 'png', 'jpg'].reduce((pre, cur, curInd) => {
-    return pre + `${curInd === 0 ? '' : ', '}url("/game/template/Intro/bg.${cur}") center/cover no-repeat`;
+    return pre + `${curInd === 0 ? '' : ', '}url("game/template/Intro/bg.${cur}") center/cover no-repeat`;
   }, '');
   let backgroundColor: any = 'rgba(0, 0, 0, 1)';
   let color: any = 'rgba(255, 255, 255, 1)';
@@ -48,7 +48,7 @@ export const intro = (sentence: ISentence): IPerform => {
   let isUserForward = false;
   for (const e of sentence.args) {
     if(e.key === 'backgroundImage'){
-      backgroundImage = `url("/game/template/Intro/${e.value}") center/cover no-repeat`;
+      backgroundImage = `url("game/template/Intro/${e.value}") center/cover no-repeat`;
     }
     if (e.key === 'backgroundColor') {
       backgroundColor = e.value || 'rgba(0, 0, 0, 1)';

--- a/packages/webgal/src/Core/gameScripts/intro.tsx
+++ b/packages/webgal/src/Core/gameScripts/intro.tsx
@@ -20,10 +20,7 @@ export const intro = (sentence: ISentence): IPerform => {
 
   const performName = `introPerform${Math.random().toString()}`;
   let fontSize: string | undefined;
-  // 'url("/game/template/Intro/bg.webp") center/cover no-repeat, url("/game/template/Intro/bga.webp") center/cover no-repeat'
-  let backgroundImage: any = ['webp', 'png', 'jpg'].reduce((pre, cur, curInd) => {
-    return pre + `${curInd === 0 ? '' : ', '}url("game/template/Intro/bg.${cur}") center/cover no-repeat`;
-  }, '');
+  let backgroundImage: string | undefined;
   let backgroundColor: any = 'rgba(0, 0, 0, 1)';
   let color: any = 'rgba(255, 255, 255, 1)';
   const animationClass: any = (type: string, length = 0) => {
@@ -46,8 +43,9 @@ export const intro = (sentence: ISentence): IPerform => {
   let delayTime = 1500;
   let isHold = false;
   let isUserForward = false;
+
   for (const e of sentence.args) {
-    if(e.key === 'backgroundImage'){
+    if (e.key === 'backgroundImage') {
       backgroundImage = `url("game/background/${e.value}") center/cover no-repeat`;
     }
     if (e.key === 'backgroundColor') {


### PR DESCRIPTION
# 说明

支持在intro中使用背景图片，图片不存在则会使用backgroundColor

# 效果

## 使用图片

![image](https://github.com/user-attachments/assets/04a0f927-ba25-47c9-99a6-513f93119fc9)

## 缺少图片

缺少background图片则会兼容backgroundColor

![image](https://github.com/user-attachments/assets/1ed7788d-3cb0-4df5-b13c-61f05471ead4)

# 特性

1. 图片尝试顺序：webp->png->jpg

2. 默认intro背景图片路径：game\template\Intro\bg.png (or webp, jpg)

