### PR TITLE
refactor: move loadScript to lib/index.js

### DIFF
--- a/packages/webgal/index.html
+++ b/packages/webgal/index.html
@@ -214,35 +214,25 @@
   <script type="module" src="/src/main.tsx"></script>
   <!--<script type="module" src="/src/Core/util/resize.ts"></script>-->
   <script>
-    function loadScript(url) {
+    function loadScript(url, type) {
       return new Promise((resolve, reject) => {
         const script = document.createElement('script');
         script.src = url;
+        if (type) script.type = type;
         script.onload = () => resolve(`Loaded: ${url}`);
-        script.onerror = (error) => reject(`Failed to load: ${url}`);
+        script.onerror = () => reject(new Error(`Failed to load: ${url}`));
         document.head.appendChild(script);
       });
     }
 
-    async function loadLive2D() {
+    async function loadLibScript() {
       try {
-        // 尝试加载 Live2D SDK，
-        // 只有在用户自行取得 Live2D 许可并放到下面的目录时，这里才可能加载成功。
-        // 本项目 **没有** 引入 Live2D SDK
-        // Attempt to load the Live2D SDK.
-        // This will only succeed if the user has obtained a Live2D license and placed it in the directory below.
-        // This project **does not** include the Live2D SDK.
-        // Live2D SDK の読み込みを試みます。
-        // ユーザーが Live2D ライセンスを取得し、以下のディレクトリに配置した場合のみ、読み込みが成功します。
-        // このプロジェクトには Live2D SDK は**含まれていません**
-        await loadScript('lib/live2d.min.js');
-        await loadScript('lib/live2dcubismcore.min.js');
-        console.log('Both Live2D scripts loaded successfully.');
+        await loadScript('lib/index.js', 'module');
       } catch (error) {
         console.error(error);
       }
     }
-    loadLive2D();
+    loadLibScript();
   </script>
   <script>
     let enterPromise = new Promise(res => window.enterPromise = res);

--- a/packages/webgal/index.html
+++ b/packages/webgal/index.html
@@ -211,8 +211,6 @@
       });
     }
   </script>
-  <script type="module" src="/src/main.tsx"></script>
-  <!--<script type="module" src="/src/Core/util/resize.ts"></script>-->
   <script>
     function loadScript(url, type) {
       return new Promise((resolve, reject) => {
@@ -234,6 +232,8 @@
     }
     loadLibScript();
   </script>
+  <script type="module" src="/src/main.tsx"></script>
+  <!--<script type="module" src="/src/Core/util/resize.ts"></script>-->
   <script>
     let enterPromise = new Promise(res => window.enterPromise = res);
     let renderPromise = new Promise(res => window.renderPromise = res);

--- a/packages/webgal/public/lib/index.js
+++ b/packages/webgal/public/lib/index.js
@@ -1,0 +1,30 @@
+function loadScript(url, type) {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = url;
+    if (type) script.type = type;
+    script.onload = () => resolve(`Loaded: ${url}`);
+    script.onerror = () => reject(new Error(`Failed to load: ${url}`));
+    document.head.appendChild(script);
+  });
+}
+
+async function loadLive2D() {
+  try {
+    // 尝试加载 Live2D SDK，
+    // 只有在用户自行取得 Live2D 许可并放到下面的目录时，这里才可能加载成功。
+    // 本项目 **没有** 引入 Live2D SDK
+    // Attempt to load the Live2D SDK.
+    // This will only succeed if the user has obtained a Live2D license and placed it in the directory below.
+    // This project **does not** include the Live2D SDK.
+    // Live2D SDK の読み込みを試みます。
+    // ユーザーが Live2D ライセンスを取得し、以下のディレクトリに配置した場合のみ、読み込みが成功します。
+    // このプロジェクトには Live2D SDK は**含まれていません**
+    await loadScript('lib/live2d.min.js');
+    await loadScript('lib/live2dcubismcore.min.js');
+    console.log('Both Live2D scripts loaded successfully.');
+  } catch (error) {
+    console.error(error);
+  }
+}
+loadLive2D();


### PR DESCRIPTION
### 调整代码结构
- 修改了`index.html`文件中的`loadScript`部分
- 将`index.html`文件中导入第三方插件的代码移动到了`public/lib/index.js`文件中
### 为什么要这样做？
- 分离项目代码与第三方插件
- 游戏开发者可以通过以下方式向项目中添加IIFE插件而不需要改动项目主体部分的代码
- - 修改`public/lib/index.js`文件中的内容
- - 修改`public/lib/index.js`文件的同时向`public/lib/`文件夹下添加新文件
- `public/lib/index.js`文件中保留了原有的导入第三方插件的逻辑，游戏开发者不需要更改以前的操作方式（将插件文件放在`public/lib/`目录下）
