### PR TITLE
feat(vite-plugin): add PIXI perform auto import plugin

### DIFF
--- a/packages/webgal/src/plugins/pixi-perform-auto-import.ts
+++ b/packages/webgal/src/plugins/pixi-perform-auto-import.ts
@@ -1,0 +1,102 @@
+import type { PluginOption } from 'vite';
+import { resolve, relative, extname } from 'path';
+import { readdirSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
+import { isEqual, debounce } from 'lodash';
+
+interface Options {
+  scriptDir: string;
+  managerDir: string;
+  outputFile?: string;
+  watchDebounce?: number;
+  clearWhenClose?: boolean;
+}
+
+export default function pixiPerformAutoImport(options: Options): PluginOption {
+  const {
+    scriptDir,
+    managerDir,
+    outputFile = 'initRegister.ts',
+    watchDebounce = 100,
+    clearWhenClose = false,
+  } = options;
+  if (!scriptDir || !managerDir) {
+    throw new Error('scriptDir and managerDir are required options');
+  }
+  const outputPath = resolve(managerDir, outputFile);
+  const relativePath = relative(managerDir, scriptDir);
+  let lastFiles: string[] = [];
+
+  function setInitFile() {
+    console.log('正在自动编写pixi特效依赖注入');
+    writeFileSync(
+      outputPath,
+      lastFiles
+        .map((v) => {
+          const filePath = relativePath + '/' + v.slice(0, v.lastIndexOf('.'));
+          return `import '${filePath}';`;
+        })
+        .join('\n') + '\n',
+      { encoding: 'utf-8' },
+    );
+  }
+
+  function getPixiPerformScriptFiles() {
+    const scriptFiles = readdirSync(scriptDir, { encoding: 'utf-8' }).filter((v) => {
+      return ['.ts', '.js', '.tsx', '.jsx'].includes(extname(v));
+    });
+    if (!isEqual(scriptFiles, lastFiles)) {
+      lastFiles = scriptFiles;
+      setInitFile();
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  return {
+    name: 'vite-plugin-webgal-pixi-perform-auto-import',
+    configResolved() {
+      // 确保输出目录存在
+      try {
+        mkdirSync(resolve(managerDir), { recursive: true });
+      } catch (e) {
+        console.error(e);
+      }
+    },
+    // 开发服务器配置
+    configureServer(server) {
+      const updateImports = debounce((path: string) => {
+        if (!path.includes(scriptDir)) {
+          return;
+        }
+        const shouldReload = getPixiPerformScriptFiles();
+        if (shouldReload) {
+          server.ws.send({ type: 'full-reload', path: outputFile });
+        }
+      }, watchDebounce);
+
+      server.watcher
+        .add(scriptDir)
+        .on('add', updateImports)
+        .on('unlink', updateImports)
+        .on('addDir', updateImports)
+        .on('unlinkDir', updateImports);
+    },
+
+    // 构建时处理
+    buildStart() {
+      getPixiPerformScriptFiles();
+    },
+
+    // 关闭时清理
+    closeBundle() {
+      if (clearWhenClose && process.env.NODE_ENV !== 'production') {
+        try {
+          unlinkSync(outputPath);
+        } catch (e) {
+          console.error(e);
+        }
+      }
+    },
+  };
+}

--- a/packages/webgal/tsconfig.node.json
+++ b/packages/webgal/tsconfig.node.json
@@ -7,6 +7,7 @@
         "moduleResolution": "node"
     },
     "include": [
-      "vite.config.ts"
+      "vite.config.ts",
+      "src/plugins/**/*.ts"
     ]
 }

--- a/packages/webgal/vite.config.ts
+++ b/packages/webgal/vite.config.ts
@@ -1,57 +1,25 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import loadVersion from 'vite-plugin-package-version';
-import { resolve, relative } from 'path';
+import { resolve } from 'path';
 import { visualizer } from 'rollup-plugin-visualizer';
-import { readdirSync, watch, writeFileSync } from 'fs';
-import { isEqual } from 'lodash';
 import Info from 'unplugin-info/vite';
+import pixiPerformAutoImport from './src/plugins/pixi-perform-auto-import';
 
 // https://vitejs.dev/config/
-
-// @ts-ignore
-const env = process.env.NODE_ENV;
-console.log(env);
-(() => {
-  const pixiPerformScriptDirPath = './src/Core/gameScripts/pixi/performs/';
-  const pixiPerformManagerDirPath = './src/Core/util/pixiPerformManager/';
-  const relativePath = relative(pixiPerformManagerDirPath, pixiPerformScriptDirPath).replaceAll('\\', '/');
-  let lastFiles: string[] = [];
-
-  function setInitFile() {
-    console.log('正在自动编写pixi特效依赖注入');
-    writeFileSync(
-      resolve(pixiPerformManagerDirPath, 'initRegister.ts'),
-      lastFiles
-        .map((v) => {
-          const filePath = relativePath + '/' + v.slice(0, v.lastIndexOf('.'));
-          return `import '${filePath}';`;
-        })
-        .join('\n') + '\n',
-      { encoding: 'utf-8' },
-    );
-  }
-
-  function getPixiPerformScriptFiles() {
-    const pixiPerformScriptFiles = readdirSync(pixiPerformScriptDirPath, { encoding: 'utf-8' }).filter((v) =>
-      ['ts', 'js', 'tsx', 'jsx'].includes(v.slice(v.indexOf('.') + 1, v.length)),
-    );
-    if (!isEqual(pixiPerformScriptFiles, lastFiles)) {
-      lastFiles = pixiPerformScriptFiles;
-      setInitFile();
-    }
-  }
-
-  getPixiPerformScriptFiles();
-
-  if (env !== 'production') watch(pixiPerformScriptDirPath, { encoding: 'utf-8' }, getPixiPerformScriptFiles);
-})();
 
 export default defineConfig({
   plugins: [
     react(),
     loadVersion(),
     Info(),
+    pixiPerformAutoImport({
+      scriptDir: resolve('src/Core/gameScripts/pixi/performs'),
+      managerDir: resolve('src/Core/util/pixiPerformManager'),
+      outputFile: 'initRegister.ts',
+      watchDebounce: 100,
+      clearWhenClose: false,
+    }),
     // @ts-ignore
     // visualizer(),
   ],


### PR DESCRIPTION
### 引言
我注意到在`webgal-engine`项目的`vite.config.ts`中有一个立即执行函数，这显然是非标做法，本人更推荐使用vite插件以实现相同的功能
### 改动
- 移除`vite.config.ts`中的立即执行函数
- 添加插件文件`pixi-perform-auto-import.ts`，位于`webgal-engine`子项目的`src/plugins`目录下
- 在`tsconfig.node.json`中添加`"src/plugins/**/*.ts"`到`include`字段，确保 TypeScript 编译器在构建或类型检查时能识别插件目录中的代码，从而避免类型错误或路径问题
- 效果和原先使用立即执行函数时一致，但现在它更符合规范了