### PR TITLE
feat: apply z index when it changes

### DIFF
--- a/packages/webgal/src/Core/gameScripts/changeFigure.ts
+++ b/packages/webgal/src/Core/gameScripts/changeFigure.ts
@@ -231,7 +231,7 @@ export function changeFigure(sentence: ISentence): IPerform {
     if (expression) {
       dispatch(stageActions.setLive2dExpression({ target: key, expression }));
     }
-    if (zIndex > 0) {
+    if (zIndex >= 0) {
       dispatch(stageActions.setFigureMetaData([key, 'zIndex', zIndex, false]));
     }
     dispatch(stageActions.setFreeFigureByKey(freeFigureItem));
@@ -260,7 +260,7 @@ export function changeFigure(sentence: ISentence): IPerform {
     if (expression) {
       dispatch(stageActions.setLive2dExpression({ target: key, expression }));
     }
-    if (zIndex > 0) {
+    if (zIndex >= 0) {
       dispatch(stageActions.setFigureMetaData([key, 'zIndex', zIndex, false]));
     }
     dispatch(setStage({ key: dispatchMap[pos], value: content }));

--- a/packages/webgal/src/Stage/MainStage/useSetFigure.ts
+++ b/packages/webgal/src/Stage/MainStage/useSetFigure.ts
@@ -9,7 +9,7 @@ import { getEnterExitAnimation } from '@/Core/Modules/animationFunctions';
 import { WebGAL } from '@/Core/WebGAL';
 
 export function useSetFigure(stageState: IStageState) {
-  const { figNameLeft, figName, figNameRight, freeFigure, live2dMotion, live2dExpression } = stageState;
+  const { figNameLeft, figName, figNameRight, freeFigure, live2dMotion, live2dExpression, figureMetaData } = stageState;
 
   /**
    * 同步 motion
@@ -28,6 +28,18 @@ export function useSetFigure(stageState: IStageState) {
       WebGAL.gameplay.pixiStage?.changeModelExpressionByKey(expression.target, expression.expression);
     }
   }, [live2dExpression]);
+
+  /**
+   * 同步元数据
+   */
+  useEffect(() => {
+    Object.entries(figureMetaData).forEach(([key, value]) => {
+      const figureObject = WebGAL.gameplay.pixiStage?.getStageObjByKey(key);
+      if (figureObject) {
+        figureObject.pixiContainer.zIndex = value.zIndex ?? 0;
+      }
+    });
+  }, [figureMetaData]);
 
   /**
    * 设置立绘

--- a/packages/webgal/src/Stage/MainStage/useSetFigure.ts
+++ b/packages/webgal/src/Stage/MainStage/useSetFigure.ts
@@ -35,8 +35,8 @@ export function useSetFigure(stageState: IStageState) {
   useEffect(() => {
     Object.entries(figureMetaData).forEach(([key, value]) => {
       const figureObject = WebGAL.gameplay.pixiStage?.getStageObjByKey(key);
-      if (figureObject) {
-        figureObject.pixiContainer.zIndex = value.zIndex ?? 0;
+      if (figureObject && value?.zIndex !== undefined) {
+        figureObject.pixiContainer.zIndex = value.zIndex;
       }
     });
   }, [figureMetaData]);


### PR DESCRIPTION
# 介绍
立绘可以在任何 `changeFigure` 语句中设置 `zIndex`, 不只限于出场
值小于 0 或不设置 zIndex, zIndex不会变化

# 测试
```js
changeBg: bg.png;
;
label: loop;
;
changeFigure:1/open_eyes.png -id=aaa -transform={"position":{"x":300}} -next -zIndex=0;
changeFigure:2/open_eyes.png -id=bbb -transform={"position":{"x":-300}} -next -zIndex=1;
: 左 1 右 0;
;
changeFigure:1/open_eyes.png -id=aaa -next -zIndex=1;
changeFigure:2/open_eyes.png -id=bbb -next -zIndex=0;
: 左 0 右 1;
;
jumpLabel: loop;
```