### PR TITLE
feat: set blink and focus param for live2d model

### DIFF
--- a/packages/webgal/src/Core/WebGAL.ts
+++ b/packages/webgal/src/Core/WebGAL.ts
@@ -1,6 +1,8 @@
 import { WebgalCore } from '@/Core/webgalCore';
+import { Live2DCore } from '@/Core/live2DCore';
 
 export const WebGAL = new WebgalCore();
+export const Live2D = new Live2DCore();
 
 // 调试，不调试给去掉
 // @ts-ignore

--- a/packages/webgal/src/Core/gameScripts/changeFigure.ts
+++ b/packages/webgal/src/Core/gameScripts/changeFigure.ts
@@ -11,7 +11,7 @@ import { assetSetter, fileType } from '@/Core/util/gameAssetsAccess/assetSetter'
 import { logger } from '@/Core/util/logger';
 import { getAnimateDuration } from '@/Core/Modules/animationFunctions';
 import { WebGAL } from '@/Core/WebGAL';
-import { baseBlinkParam, BlinkParam } from '@/Core/live2DCore';
+import { baseBlinkParam, BlinkParam, FocusParam } from '@/Core/live2DCore';
 /**
  * 更改立绘
  * @param sentence 语句
@@ -25,6 +25,7 @@ export function changeFigure(sentence: ISentence): IPerform {
   let motion = '';
   let expression = '';
   let blink: BlinkParam | null = null;
+  let focus: FocusParam | null = null;
   let key = '';
   let duration = 500;
   let mouthOpen = '';
@@ -73,14 +74,20 @@ export function changeFigure(sentence: ISentence): IPerform {
       case 'expression':
         expression = e.value.toString();
         break;
-      case 'blink': {
+      case 'blink':
         try {
           blink = JSON.parse(e.value.toString()) as BlinkParam;
         } catch (error) {
           logger.error('Failed to parse blink parameter:', error);
         }
         break;
-      }
+      case 'focus':
+        try {
+          focus = JSON.parse(e.value.toString()) as FocusParam;
+        } catch (error) {
+          logger.error('Failed to parse focus parameter:', error);
+        }
+        break;
       case 'mouthOpen':
         mouthOpen = e.value.toString();
         mouthOpen = assetSetter(mouthOpen, fileType.figure);
@@ -244,6 +251,12 @@ export function changeFigure(sentence: ISentence): IPerform {
     if (blink) {
       dispatch(stageActions.setLive2dBlink({ target: key, blink }));
     }
+    if (blink) {
+      dispatch(stageActions.setLive2dBlink({ target: key, blink }));
+    }
+    if (focus) {
+      dispatch(stageActions.setLive2dFocus({ target: key, focus }));
+    }
     if (zIndex >= 0) {
       dispatch(stageActions.setFigureMetaData([key, 'zIndex', zIndex, false]));
     }
@@ -275,6 +288,9 @@ export function changeFigure(sentence: ISentence): IPerform {
     }
     if (blink) {
       dispatch(stageActions.setLive2dBlink({ target: key, blink }));
+    }
+    if (focus) {
+      dispatch(stageActions.setLive2dFocus({ target: key, focus }));
     }
     if (zIndex >= 0) {
       dispatch(stageActions.setFigureMetaData([key, 'zIndex', zIndex, false]));

--- a/packages/webgal/src/Core/gameScripts/changeFigure.ts
+++ b/packages/webgal/src/Core/gameScripts/changeFigure.ts
@@ -11,6 +11,7 @@ import { assetSetter, fileType } from '@/Core/util/gameAssetsAccess/assetSetter'
 import { logger } from '@/Core/util/logger';
 import { getAnimateDuration } from '@/Core/Modules/animationFunctions';
 import { WebGAL } from '@/Core/WebGAL';
+import { baseBlinkParam, BlinkParam } from '@/Core/live2DCore';
 /**
  * 更改立绘
  * @param sentence 语句
@@ -23,6 +24,7 @@ export function changeFigure(sentence: ISentence): IPerform {
   let isFreeFigure = false;
   let motion = '';
   let expression = '';
+  let blink: BlinkParam | null = null;
   let key = '';
   let duration = 500;
   let mouthOpen = '';
@@ -71,6 +73,14 @@ export function changeFigure(sentence: ISentence): IPerform {
       case 'expression':
         expression = e.value.toString();
         break;
+      case 'blink': {
+        try {
+          blink = JSON.parse(e.value.toString()) as BlinkParam;
+        } catch (error) {
+          logger.error('Failed to parse blink parameter:', error);
+        }
+        break;
+      }
       case 'mouthOpen':
         mouthOpen = e.value.toString();
         mouthOpen = assetSetter(mouthOpen, fileType.figure);
@@ -231,6 +241,9 @@ export function changeFigure(sentence: ISentence): IPerform {
     if (expression) {
       dispatch(stageActions.setLive2dExpression({ target: key, expression }));
     }
+    if (blink) {
+      dispatch(stageActions.setLive2dBlink({ target: key, blink }));
+    }
     if (zIndex >= 0) {
       dispatch(stageActions.setFigureMetaData([key, 'zIndex', zIndex, false]));
     }
@@ -259,6 +272,9 @@ export function changeFigure(sentence: ISentence): IPerform {
     }
     if (expression) {
       dispatch(stageActions.setLive2dExpression({ target: key, expression }));
+    }
+    if (blink) {
+      dispatch(stageActions.setLive2dBlink({ target: key, blink }));
     }
     if (zIndex >= 0) {
       dispatch(stageActions.setFigureMetaData([key, 'zIndex', zIndex, false]));

--- a/packages/webgal/src/Core/live2DCore.ts
+++ b/packages/webgal/src/Core/live2DCore.ts
@@ -1,0 +1,44 @@
+/**
+ * 眨眼参数，毫秒
+ */
+export interface BlinkParam {
+  blinkInterval: number; // 眨眼间隔
+  blinkIntervalRandom: number; // 眨眼间隔随机范围
+  closingDuration: number; // 闭眼
+  closedDuration: number; // 保持闭眼
+  openingDuration: number; // 睁眼
+}
+
+export const baseBlinkParam: BlinkParam = {
+  blinkInterval: 24 * 60 * 60 * 1000, // 24小时
+  blinkIntervalRandom: 1000,
+  closingDuration: 100,
+  closedDuration: 50,
+  openingDuration: 150,
+};
+
+export class Live2DCore {
+  public isAvailable = false;
+
+  public Live2DModel: any;
+  public SoundManager: any;
+  public Config: any;
+
+  public constructor() {
+    this.initLive2D();
+  }
+
+  private async initLive2D() {
+    try {
+      const { Live2DModel, SoundManager, config } = await import('pixi-live2d-display-webgal');
+      this.Live2DModel = Live2DModel;
+      this.SoundManager = SoundManager;
+      this.Config = config;
+      this.isAvailable = true;
+      console.info('live2d lib load success');
+    } catch (error) {
+      this.isAvailable = false;
+      console.info('live2d lib load failed', error);
+    }
+  }
+}

--- a/packages/webgal/src/Core/live2DCore.ts
+++ b/packages/webgal/src/Core/live2DCore.ts
@@ -17,6 +17,18 @@ export const baseBlinkParam: BlinkParam = {
   openingDuration: 150,
 };
 
+export interface FocusParam {
+  x: number; // 焦点X位置
+  y: number; // 焦点Y位置
+  instant: boolean; // 是否瞬间切换焦点
+}
+
+export const baseFocusParam: FocusParam = {
+  x: 0,
+  y: 0,
+  instant: false,
+};
+
 export class Live2DCore {
   public isAvailable = false;
 

--- a/packages/webgal/src/Stage/MainStage/useSetFigure.ts
+++ b/packages/webgal/src/Stage/MainStage/useSetFigure.ts
@@ -7,9 +7,19 @@ import { generateUniversalSoftOffAnimationObj } from '@/Core/controller/stage/pi
 
 import { getEnterExitAnimation } from '@/Core/Modules/animationFunctions';
 import { WebGAL } from '@/Core/WebGAL';
+import { use } from 'i18next';
 
 export function useSetFigure(stageState: IStageState) {
-  const { figNameLeft, figName, figNameRight, freeFigure, live2dMotion, live2dExpression, figureMetaData } = stageState;
+  const {
+    figNameLeft,
+    figName,
+    figNameRight,
+    freeFigure,
+    live2dMotion,
+    live2dExpression,
+    live2dBlink,
+    figureMetaData,
+  } = stageState;
 
   /**
    * 同步 motion
@@ -28,6 +38,12 @@ export function useSetFigure(stageState: IStageState) {
       WebGAL.gameplay.pixiStage?.changeModelExpressionByKey(expression.target, expression.expression);
     }
   }, [live2dExpression]);
+
+  useEffect(() => {
+    for (const blink of live2dBlink) {
+      WebGAL.gameplay.pixiStage?.changeModelBlinkByKey(blink.target, blink.blink);
+    }
+  }, [live2dBlink]);
 
   /**
    * 同步元数据

--- a/packages/webgal/src/Stage/MainStage/useSetFigure.ts
+++ b/packages/webgal/src/Stage/MainStage/useSetFigure.ts
@@ -18,6 +18,7 @@ export function useSetFigure(stageState: IStageState) {
     live2dMotion,
     live2dExpression,
     live2dBlink,
+    live2dFocus,
     figureMetaData,
   } = stageState;
 
@@ -39,11 +40,23 @@ export function useSetFigure(stageState: IStageState) {
     }
   }, [live2dExpression]);
 
+  /**
+   * 同步 blink
+   */
   useEffect(() => {
     for (const blink of live2dBlink) {
       WebGAL.gameplay.pixiStage?.changeModelBlinkByKey(blink.target, blink.blink);
     }
   }, [live2dBlink]);
+
+  /**
+   * 同步 focus
+   */
+  useEffect(() => {
+    for (const focus of live2dFocus) {
+      WebGAL.gameplay.pixiStage?.changeModelFocusByKey(focus.target, focus.focus);
+    }
+  }, [live2dFocus]);
 
   /**
    * 同步元数据

--- a/packages/webgal/src/store/stageInterface.ts
+++ b/packages/webgal/src/store/stageInterface.ts
@@ -1,5 +1,5 @@
 import { ISentence } from '@/Core/controller/scene/sceneInterface';
-import { BlinkParam } from '@/Core/live2DCore';
+import { BlinkParam, FocusParam } from '@/Core/live2DCore';
 
 /**
  * 游戏内变量
@@ -162,6 +162,11 @@ export interface ILive2DBlink {
   blink: BlinkParam;
 }
 
+export interface ILive2DFocus {
+  target: string;
+  focus: FocusParam;
+}
+
 export interface IFigureMetadata {
   zIndex?: number;
 }
@@ -205,6 +210,7 @@ export interface IStageState {
   live2dMotion: ILive2DMotion[];
   live2dExpression: ILive2DExpression[];
   live2dBlink: ILive2DBlink[];
+  live2dFocus: ILive2DFocus[];
   // 当前演出的延迟，用于做对话插演出！
   // currentPerformDelay:number
   currentConcatDialogPrev: string;

--- a/packages/webgal/src/store/stageInterface.ts
+++ b/packages/webgal/src/store/stageInterface.ts
@@ -1,4 +1,5 @@
 import { ISentence } from '@/Core/controller/scene/sceneInterface';
+import { BlinkParam } from '@/Core/live2DCore';
 
 /**
  * 游戏内变量
@@ -156,6 +157,11 @@ export interface ILive2DExpression {
   expression: string;
 }
 
+export interface ILive2DBlink {
+  target: string;
+  blink: BlinkParam;
+}
+
 export interface IFigureMetadata {
   zIndex?: number;
 }
@@ -198,6 +204,7 @@ export interface IStageState {
   currentDialogKey: string; // 当前对话的key
   live2dMotion: ILive2DMotion[];
   live2dExpression: ILive2DExpression[];
+  live2dBlink: ILive2DBlink[];
   // 当前演出的延迟，用于做对话插演出！
   // currentPerformDelay:number
   currentConcatDialogPrev: string;

--- a/packages/webgal/src/store/stageReducer.ts
+++ b/packages/webgal/src/store/stageReducer.ts
@@ -10,6 +10,7 @@ import {
   IFreeFigure,
   ILive2DBlink,
   ILive2DExpression,
+  ILive2DFocus,
   ILive2DMotion,
   IRunPerform,
   ISetGameVar,
@@ -62,6 +63,7 @@ export const initState: IStageState = {
   live2dMotion: [],
   live2dExpression: [],
   live2dBlink: [],
+  live2dFocus: [],
   // currentPerformDelay: 0
   currentConcatDialogPrev: '',
   enableFilm: '',
@@ -228,6 +230,18 @@ const stageSlice = createSlice({
       } else {
         // Update the existing blink
         state.live2dBlink[index].blink = blink;
+      }
+    },
+    setLive2dFocus: (state, action: PayloadAction<ILive2DFocus>) => {
+      const { target, focus } = action.payload;
+
+      const index = state.live2dFocus.findIndex((e) => e.target === target);
+      if (index < 0) {
+        // Add a new focus
+        state.live2dFocus.push({ target, focus });
+      } else {
+        // Update the existing focus
+        state.live2dFocus[index].focus = focus;
       }
     },
     replaceUIlable: (state, action: PayloadAction<[string, string]>) => {

--- a/packages/webgal/src/store/stageReducer.ts
+++ b/packages/webgal/src/store/stageReducer.ts
@@ -8,6 +8,7 @@ import {
   IEffect,
   IFigureMetadata,
   IFreeFigure,
+  ILive2DBlink,
   ILive2DExpression,
   ILive2DMotion,
   IRunPerform,
@@ -60,6 +61,7 @@ export const initState: IStageState = {
   currentDialogKey: 'initial',
   live2dMotion: [],
   live2dExpression: [],
+  live2dBlink: [],
   // currentPerformDelay: 0
   currentConcatDialogPrev: '',
   enableFilm: '',
@@ -214,6 +216,18 @@ const stageSlice = createSlice({
       } else {
         // Update the existing expression
         state.live2dExpression[index].expression = expression;
+      }
+    },
+    setLive2dBlink: (state, action: PayloadAction<ILive2DBlink>) => {
+      const { target, blink } = action.payload;
+
+      const index = state.live2dBlink.findIndex((e) => e.target === target);
+      if (index < 0) {
+        // Add a new blink
+        state.live2dBlink.push({ target, blink });
+      } else {
+        // Update the existing blink
+        state.live2dBlink[index].blink = blink;
       }
     },
     replaceUIlable: (state, action: PayloadAction<[string, string]>) => {


### PR DESCRIPTION
# 介绍
_此 PR 以 OpenWebGAL/pixi-live2d-display-webgal#9 为前置条件_
为 changeFigure 新增 `-blink` 和 `-focus` 参数，以控制眨眼和注视，仅限 Live2D 立绘

# 主要更改
- changeFigure 新增 `-blink` 和 `-focus` 参数
- 舞台 和 状态表 会记录这两个数据
- 移除了不必要的 使注视和眨眼不可用 的代码
- 将 Live2D 相关的加载移动到单独的类中
- 导入了 config，虽然现在没用，但合并 OpenWebGAL/pixi-live2d-display-webgal#7 后就有用了

# 语法

## blink
允许只填写部分属性，其他属性会继承已有值
默认间隔为 24 小时

`真正的眨眼间隔= blinkInterval+-blinkIntervalRandom`

```ts
-blink={
  "blinkInterval":眨眼间隔时长(毫秒),
  "blinkIntervalRandom":眨眼间隔时长随机+-范围(毫秒),
  "openingDuration":睁眼动画时长(毫秒),
  "closingDuration":闭眼动画时长(毫秒),
  "closedDuration":保持闭眼时长(毫秒)
}
```

## focus
允许只填写部分属性，其他属性会继承已有值

```ts
-focus={
  "x":注视 x 方向, [-1, 1], 默认0,
  "y":注视 y 方向, [-1, 1], 默认0,
  "instant":是否立即设置, 布尔值, 默认false
}
```