### PR TITLE
refactor: use end state effect

### DIFF
--- a/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/PixiController.ts
@@ -23,7 +23,7 @@ export interface IAnimationObject {
   setStartState: Function;
   setEndState: Function;
   tickerFunc: PIXI.TickerCallback<number>;
-  getEndFilterEffect?: Function;
+  getEndStateEffect?: Function;
 }
 
 interface IStageAnimationObject {
@@ -291,33 +291,14 @@ export default class PixiStage {
       const thisTickerFunc = this.stageAnimations[index];
       this.currentApp?.ticker.remove(thisTickerFunc.animationObject.tickerFunc);
       thisTickerFunc.animationObject.setEndState();
-      const webgalFilters = thisTickerFunc.animationObject.getEndFilterEffect?.() ?? {};
+      const endStateEffect = thisTickerFunc.animationObject.getEndStateEffect?.() ?? {};
       this.unlockStageObject(thisTickerFunc.targetKey ?? 'default');
       if (thisTickerFunc.targetKey) {
         const target = this.getStageObjByKey(thisTickerFunc.targetKey);
         if (target) {
-          const targetTransform = {
-            alpha: target.pixiContainer.alpha,
-            scale: {
-              x: target.pixiContainer.scale.x,
-              y: target.pixiContainer.scale.y,
-            },
-            // pivot: {
-            //   x: target.pixiContainer.pivot.x,
-            //   y: target.pixiContainer.pivot.y,
-            // },
-            position: {
-              x: target.pixiContainer.x,
-              y: target.pixiContainer.y,
-            },
-            rotation: target.pixiContainer.rotation,
-            // @ts-ignore
-            blur: target.pixiContainer.blur,
-            ...webgalFilters,
-          };
           let effect: IEffect = {
             target: thisTickerFunc.targetKey,
-            transform: targetTransform,
+            transform: endStateEffect,
           };
           webgalStore.dispatch(stageActions.updateEffect(effect));
           // if (!this.notUpdateBacklogEffects) updateCurrentBacklogEffects(webgalStore.getState().stage.effects);

--- a/packages/webgal/src/Core/controller/stage/pixi/animations/timeline.ts
+++ b/packages/webgal/src/Core/controller/stage/pixi/animations/timeline.ts
@@ -126,17 +126,11 @@ export function generateTimelineObj(
     return timeline[timeline.length - 1];
   }
 
-  function getEndFilterEffect() {
-    const endSegment = timeline[timeline.length - 1];
-    const { alpha, rotation, blur, duration, scale, position, ...rest } = endSegment;
-    return rest;
-  }
-
   return {
     setStartState,
     setEndState,
     tickerFunc,
-    getEndFilterEffect,
+    getEndStateEffect,
   };
 }
 


### PR DESCRIPTION
# 介绍
将 animationObject 中的 `getEndFilterEffect` 改为 `getEndStateEffect`，以便获得完整的终态 Effect
在 `removeAnimationWithSetEffect` 中，使用 `getEndStateEffect` 避免强行打断动画时，意外获取了当前态的位置，缩放，旋转，不透明度，模糊属性