### PR TITLE
fix: properly escaping "." in regex patterns

### DIFF
--- a/packages/webgal/src/hooks/useEscape.ts
+++ b/packages/webgal/src/hooks/useEscape.ts
@@ -20,7 +20,7 @@ const escapeMap = [
     val: ';',
   },
   {
-    reg: /\\./g,
+    reg: /\\\./g,
     val: '.',
   },
 ];


### PR DESCRIPTION
在hooks/useEscape中，对英文句点进行转义时似乎在正则表达式中遗漏了一次转义，因此任何跟在反斜杠后的常规字符都会被替换为"."。例如`\a`，`\b`都会变成`.`。
```js
  {
    reg: /\\./g,
    val: '.',
  },
```
添加转义，可以正确的起到转义英文句点的作用。不确定这是否是符合预期的设计，不过通常应该不会做这种过于宽泛的转义？
```js
  {
    reg: /\\\./g,
    val: '.',
  },
```