### PR TITLE
fix: resume center argument in say command

### DIFF
--- a/packages/webgal/src/Core/gameScripts/say.ts
+++ b/packages/webgal/src/Core/gameScripts/say.ts
@@ -90,11 +90,13 @@ export const say = (sentence: ISentence): IPerform => {
   let performSimulateVocalTimeout: ReturnType<typeof setTimeout> | null = null;
   let performSimulateVocalDelay = 0;
 
-  let pos: 'center' | 'left' | 'right' = 'center';
+  let pos: '' | 'center' | 'left' | 'right' = '';
   const leftFromArgs = getBooleanArgByKey(sentence, 'left') ?? false;
   const rightFromArgs = getBooleanArgByKey(sentence, 'right') ?? false;
+  const centerFromArgs = getBooleanArgByKey(sentence, 'center') ?? false;
   if (leftFromArgs) pos = 'left';
   if (rightFromArgs) pos = 'right';
+  if (centerFromArgs) pos = 'center';
 
   let key = getStringArgByKey(sentence, 'figureId') ?? '';
 


### PR DESCRIPTION
# 介绍
修复模拟语音延迟永远为 true 的问题。源于 #739 意外把 center 参数移除，并将 center 作为默认值