### PR TITLE
fix: parse interpolated vocal shorthand

### DIFF
--- a/packages/parser/src/scriptParser/argsParser.ts
+++ b/packages/parser/src/scriptParser/argsParser.ts
@@ -30,7 +30,10 @@ export function argsParser(
       argValue = undefined;
     }
     // 判断是不是语音参数
-    if (argName.toLowerCase().match(/.ogg|.mp3|.wav|.opus/)) {
+    const isVocalShorthand =
+      argValue === undefined &&
+      (/\.(?:ogg|mp3|wav|opus)$/i.test(argName) || /(?<!\\)\{.+?\}/.test(argName));
+    if (isVocalShorthand) {
       returnArrayList.push({
         key: 'vocal',
         value: assetSetter(e, fileType.vocal),

--- a/packages/parser/test/parser.test.ts
+++ b/packages/parser/test/parser.test.ts
@@ -68,6 +68,19 @@ test("args", async () => {
   expectSentenceIn(result.sentenceList, expectSentenceItem);
 });
 
+test("interpolated vocal shorthand", () => {
+  const parser = new SceneParser(() => {}, (fileName, assetType) => {
+    return assetType === fileType.vocal ? `./game/vocal/${fileName}` : fileName;
+  }, ADD_NEXT_ARG_LIST, SCRIPT_CONFIG);
+
+  const result = parser.parse('Narrator:Line -{voiceFile};', "vocal", "/vocal.txt");
+
+  expect(result.sentenceList[0].args).toContainEqual({
+    key: 'vocal',
+    value: './game/vocal/{voiceFile}',
+  });
+});
+
 test("choose", async () => {
 
   const sceneRaw = await fsp.readFile('test/test-resources/choose.txt');


### PR DESCRIPTION
## Summary

- recognize an unescaped runtime interpolation as vocal shorthand when no explicit argument value is present
- pass shorthand such as `-{voiceFile}` through the vocal asset path resolver
- add a parser regression test for the interpolated shorthand form

## Validation

- `yarn parser:test --run` (30 tests passed)
- `yarn parser:build`
- `yarn webgal:build`

Closes #888