### PR TITLE
fix: skip dynamic asset prefetch

### DIFF
--- a/packages/webgal/src/Core/util/prefetcher/assetsPrefetcher.ts
+++ b/packages/webgal/src/Core/util/prefetcher/assetsPrefetcher.ts
@@ -28,6 +28,8 @@ const uniqueAssetsByUrl = (assetList: Array<IAsset>) => {
   });
 };
 
+const hasRuntimeInterpolation = (url: string) => /(?<!\\)\{.*?\}/.test(url);
+
 const inferPrefetchAs = (assetType: fileType): string => {
   switch (assetType) {
     case fileType.background:
@@ -109,6 +111,10 @@ export const assetsPrefetcher = (assetList: Array<IAsset>, options: IAssetsPrefe
   //   return;
   // }
   const filteredAssetList = uniqueAssetsByUrl(assetList).filter((asset) => {
+    if (hasRuntimeInterpolation(asset.url)) {
+      logger.debug(`跳过包含运行时变量的资源预加载：${asset.url}`);
+      return false;
+    }
     if (options.ignoreLineGate) {
       return true;
     }


### PR DESCRIPTION
## Summary

- detect unescaped runtime interpolation in asset URLs before queueing prefetch work
- skip unresolved dynamic URLs instead of requesting literal paths such as `/game/figure/{p_phone}`
- preserve prefetching for ordinary URLs and escaped literal braces

## Root cause

Asset prefetch runs while parsing a scene, before runtime variable values are available, so interpolated paths cannot be resolved safely at that point.

## Validation

- `yarn webgal:build`
- checked ordinary, interpolated, multiple-segment, and escaped-brace URL cases

Closes #997