### PR TITLE
fix(webgal): map global to globalThis in browser builds

### DIFF
--- a/packages/webgal/vite.config.ts
+++ b/packages/webgal/vite.config.ts
@@ -27,6 +27,11 @@ export default defineConfig({
       '@': resolve('src'),
     },
   },
+  // angular-expressions accesses Node's `global` during expression compilation.
+  // Map it to the browser's standard globalThis in the generated bundle.
+  define: {
+    global: 'globalThis',
+  },
   build: {
     // sourcemap: true,
   },


### PR DESCRIPTION
## Summary

Map the browser bundle's `global` identifier to `globalThis` so expression evaluation works in browser builds.

## Problem

`angular-expressions@1.4.3` accesses Node's `global` during `compile()`:

```js
if (global.storeFnString) {
  global.storeFnString(fnString);
}
```

When WebGAL runs in a browser bundle, `global` is undefined. This makes expression evaluation fail with:

```text
ReferenceError: global is not defined
```

The failure affects script expressions such as `setVar:morale=morale+1` and conditional evaluation used by `-when`. In the current error handling, those failures can silently turn into an empty variable value or a false condition.

## Fix

Configure Vite to replace `global` with the browser-standard `globalThis` in the generated bundle. This keeps the fix scoped to the browser build and avoids changing WebGAL's expression semantics.

## Validation

- `git diff --check` passes.
- The project's existing PR workflow will run parser tests and the full WebGAL build.

This is separate from #1005, which addresses expression evaluation semantics and variable extraction rather than the browser `global` compatibility failure.
