### PR TITLE
fix(parser): accumulate assets and subscenes in place to remove superlinear cost

### DIFF
--- a/packages/parser/src/sceneParser.ts
+++ b/packages/parser/src/sceneParser.ts
@@ -51,9 +51,16 @@ export const sceneParser = (
         SCRIPT_CONFIG_MAP,
         index,
       );
-      // 在这里解析出语句可能携带的资源和场景，合并到 assetsList 和 subSceneList
-      assetsList = [...assetsList, ...returnSentence.sentenceAssets];
-      subSceneList = [...subSceneList, ...returnSentence.subScene];
+      // 在这里解析出语句可能携带的资源和场景，合并到 assetsList 和 subSceneList。
+      // 必须就地追加：如果写成 [...assetsList, ...sentenceAssets]，每条语句都要复制
+      // 一次已累积的列表，整体退化成 Θ(资源数²)——资源密集的场景脚本（几乎每条语句
+      // 都带 bg / figure / vocal）在数千条语句规模下会明显变慢。
+      for (const asset of returnSentence.sentenceAssets) {
+        assetsList.push(asset);
+      }
+      for (const subScene of returnSentence.subScene) {
+        subSceneList.push(subScene);
+      }
       return returnSentence;
     },
   );

--- a/packages/parser/test/parser.test.ts
+++ b/packages/parser/test/parser.test.ts
@@ -291,6 +291,30 @@ test("scene assets skip entries with empty urls", async () => {
   expect(result.assetsList).toEqual([]);
 });
 
+test("scene assets and subscenes are accumulated from every statement", async () => {
+  let prefetchedAssets: IAsset[] = [];
+  const parser = new SceneParser((assetList) => {
+    prefetchedAssets = assetList;
+  }, (fileName, assetType) => {
+    return fileName;
+  }, ADD_NEXT_ARG_LIST, SCRIPT_CONFIG);
+
+  const result = parser.parse(`changeBg:a.webp;
+changeFigure:b.png -id=b;
+say:voice line -vocal=c.mp3;
+changeBg:a.webp;
+callScene:chapter1.txt;
+callScene:chapter2.txt;`, 'test', 'test');
+
+  expect(result.assetsList).toEqual([
+    { name: 'a.webp', url: 'a.webp', type: fileType.background, lineNumber: 0 },
+    { name: 'b.png', url: 'b.png', type: fileType.figure, lineNumber: 1 },
+    { name: 'c.mp3', url: 'c.mp3', type: fileType.vocal, lineNumber: 2 },
+  ]);
+  expect(prefetchedAssets).toEqual(result.assetsList);
+  expect(result.subSceneList).toEqual(['chapter1.txt', 'chapter2.txt']);
+});
+
 test("wait command", async () => {
   const parser = new SceneParser((assetList) => {
   }, (fileName, assetType) => {

--- a/packages/parser/test/parserAssetsScaling.test.ts
+++ b/packages/parser/test/parserAssetsScaling.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from 'vitest';
+
+import { ADD_NEXT_ARG_LIST, SCRIPT_CONFIG } from '../src/config/scriptConfig';
+import SceneParser from '../src/index';
+
+/**
+ * 资源密集脚本：几乎每条语句都带一个资源引用（bg / figure / vocal）。
+ * sceneParser 会把每条语句的资源累积到场景级 assetsList。
+ */
+function buildAssetDenseScene(statementCount: number): string {
+  const lines: string[] = [];
+  for (let index = 0; index < statementCount; index++) {
+    switch (index % 3) {
+      case 0: {
+        lines.push(`changeBg:background-${index % 40}.webp;`);
+        break;
+      }
+      case 1: {
+        lines.push(
+          `character-${index % 6}:line ${index} -vocal=voice-${index}.mp3;`,
+        );
+        break;
+      }
+      default: {
+        lines.push(
+          `changeFigure:figure-${index % 12}.png -id=figure-${index % 12};`,
+        );
+      }
+    }
+  }
+  return lines.join('\n');
+}
+
+const SMALL_STATEMENT_COUNT = 4000;
+const LARGE_STATEMENT_COUNT = SMALL_STATEMENT_COUNT * 4;
+/** 语句数 ×4 时允许的最大耗时倍率，阈值刻意放宽，只用于拦截复杂度回退 */
+const MAX_TIME_RATIO = 8;
+
+function measureParseTime(source: string): number {
+  const parser = new SceneParser(
+    () => { },
+    (fileName) => fileName,
+    ADD_NEXT_ARG_LIST,
+    SCRIPT_CONFIG,
+  );
+
+  let best = Number.POSITIVE_INFINITY;
+  for (let round = 0; round < 3; round++) {
+    const start = performance.now();
+    parser.parse(source, 'scaling', '/scaling.txt');
+    best = Math.min(best, performance.now() - start);
+  }
+  return best;
+}
+
+test('asset accumulation stays linear in the number of asset references', () => {
+  const smallSource = buildAssetDenseScene(SMALL_STATEMENT_COUNT);
+  const largeSource = buildAssetDenseScene(LARGE_STATEMENT_COUNT);
+
+  // 预热：把首次调用的编译开销排除在测量之外
+  measureParseTime(smallSource);
+
+  const smallMs = measureParseTime(smallSource);
+  const largeMs = measureParseTime(largeSource);
+
+  // 就地追加累积时，语句数 ×4 的耗时约为 4 倍；
+  // 旧的全量复制实现（[...assetsList, ...sentenceAssets]）会退化成 Θ(资源数²)，
+  // 同样的 4 倍规模下耗时约为 12 倍以上。
+  expect(largeMs / smallMs).toBeLessThan(MAX_TIME_RATIO);
+});


### PR DESCRIPTION
## 改动

`sceneParser` 累积语句资源时写成了 `assetsList = [...assetsList, ...sentenceAssets]`，每条语句都会复制一遍当前已累积的列表，解析成本因此随资源引用数二次增长。资源密集的脚本（每条语句都带 `bg` / `changeFigure` / `say -vocal`）规模上去后开销很明显。

改成就地 `push`。累积结果、顺序、去重以及 `assetsPrefetcher` 的入参都不变；另外补了两条测试：多条语句的资源/子场景累积与去重，以及一个复杂度守卫（语句数 ×4 时耗时不得超过 ×8，旧实现在该用例下比值 22）。

## 效果

每条语句都带一个资源引用时（本机实测）：8000 条语句 41.1ms → 11.8ms，4000 条 13.1ms → 5.9ms。编辑器类调用方每次编辑都会整篇解析，这部分直接体现为输入延迟。

## 验证

`cd packages/parser && npx vitest run`，31 个用例通过。
